### PR TITLE
Provide two different wrappers for FormattedMessage

### DIFF
--- a/examples/basic/Page.re
+++ b/examples/basic/Page.re
@@ -21,15 +21,15 @@ let make = (~locale, ~setLocale, _) => {
           </button>
         </div>
         <div className="message">
-          <ReactIntl.FormattedMessage message=pageLocale##hello />
+          <ReactIntl.DefinedMessage message=pageLocale##hello />
           (" " |> ReasonReact.stringToElement)
-          <ReactIntl.FormattedMessage message=pageLocale##world />
+          <ReactIntl.DefinedMessage message=pageLocale##world />
         </div>
         <ReactIntl.IntlInjector>
           ...(
                intl =>
                  <div>
-                   <ReactIntl.FormattedMessage message=pageLocale##today />
+                   <ReactIntl.DefinedMessage message=pageLocale##today />
                    (" " |> ReasonReact.stringToElement)
                    (
                      Js.Date.now()
@@ -40,6 +40,6 @@ let make = (~locale, ~setLocale, _) => {
                  </div>
              )
         </ReactIntl.IntlInjector>
-      </div>
+      </div>,
   };
 };

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -573,6 +573,31 @@ module FormattedMessage = {
   external reactClass : ReasonReact.reactClass = "FormattedMessage";
   let make =
       (
+        ~id: string,
+        ~defaultMessage: string,
+        ~values: option(Js.t({..}))=?,
+        ~tagName: option(domTag)=?,
+        _,
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass,
+      ~props={
+        "id": id,
+        "defaultMessage": defaultMessage,
+        "values": values |> Js.Nullable.fromOption,
+        "tagName": tagName |> mapOptDomTagToString |> Js.Nullable.fromOption,
+      },
+      [||],
+    );
+};
+
+/* DefinedMessage is another wrapper for FormattedMessage.
+   It takes the id and defaultMessage props from a passed message object. */
+module DefinedMessage = {
+  [@bs.module "react-intl"]
+  external reactClass : ReasonReact.reactClass = "FormattedMessage";
+  let make =
+      (
         ~message: message,
         ~values: option(Js.t({..}))=?,
         ~tagName: option(domTag)=?,


### PR DESCRIPTION
Provide two different wrappers for FormattedMessage accepting different props.

* `FormattedMessage` has `id` and `defaultMessage`
* `DefinedMessage` has `message` (as defined using `defineMessages` beforehand).

I tested that examples/basic still works.