### PR TITLE
Inline IntlInjector implementation to fix #2.

### DIFF
--- a/src/IntlInjector.js
+++ b/src/IntlInjector.js
@@ -1,9 +1,0 @@
-var injectIntl = require("react-intl").injectIntl;
-
-var IntlInjector = function IntlInjector(_ref) {
-  var intl = _ref.intl,
-      children = _ref.children;
-  return children(intl);
-};
-
-exports.default = injectIntl(IntlInjector);

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -559,8 +559,14 @@ let mapIntlJsToReason = (intlJs: intlJs('t)) : intl('a) => {
 };
 
 module IntlInjector = {
-  [@bs.module "./IntlInjector.js"]
-  external reactClass : ReasonReact.reactClass = "default";
+  let reactClass: ReasonReact.reactClass = [%bs.raw
+    {|
+    require("react-intl").injectIntl(function(_ref) {
+      var intl = _ref.intl, children = _ref.children;
+      return children(intl);
+    })
+    |}
+  ];
   let make = children =>
     ReasonReact.wrapJsForReason(
       ~reactClass, ~props=Js.Obj.empty(), (intlJs: intlJs('t)) =>


### PR DESCRIPTION
This fixes the build issues mentioned in #2 by inlining the existing implementation into ReactIntl.re.