### PR TITLE
Upgrade dependencies (bs-platform 3.0.0, react-intl 0.4.1).

### DIFF
--- a/examples/basic/Page.re
+++ b/examples/basic/Page.re
@@ -7,7 +7,7 @@ let make = (~locale, ~setLocale, _) => {
   let setEnLocale = (_) => Locale.En |> setLocale;
   let setRuLocale = (_) => Locale.Ru |> setLocale;
   let localeToElement = locale =>
-    locale |> Locale.mapLocaleToString |> ReasonReact.stringToElement;
+    locale |> Locale.mapLocaleToString |> ReasonReact.string;
   {
     ...component,
     render: (_) =>
@@ -22,7 +22,7 @@ let make = (~locale, ~setLocale, _) => {
         </div>
         <div className="message">
           <ReactIntl.DefinedMessage message=pageLocale##hello />
-          (" " |> ReasonReact.stringToElement)
+          (" " |> ReasonReact.string)
           <ReactIntl.DefinedMessage message=pageLocale##world />
         </div>
         <ReactIntl.IntlInjector>
@@ -30,18 +30,14 @@ let make = (~locale, ~setLocale, _) => {
                intl =>
                  <div>
                    <ReactIntl.DefinedMessage message=pageLocale##today />
-                   (" " |> ReasonReact.stringToElement)
-                   (
-                     Js.Date.make()
-                     |> intl.formatDate
-                     |> ReasonReact.stringToElement
-                   )
-                   (" (intl.formatDate)" |> ReasonReact.stringToElement)
+                   (" " |> ReasonReact.string)
+                   (Js.Date.make() |> intl.formatDate |> ReasonReact.string)
+                   (" (intl.formatDate)" |> ReasonReact.string)
                    <br />
                    <ReactIntl.DefinedMessage message=pageLocale##today />
-                   (" " |> ReasonReact.stringToElement)
+                   (" " |> ReasonReact.string)
                    <ReactIntl.FormattedDate value=(Js.Date.make()) />
-                   (" (FormattedDate)" |> ReasonReact.stringToElement)
+                   (" (FormattedDate)" |> ReasonReact.string)
                  </div>
              )
         </ReactIntl.IntlInjector>

--- a/package.json
+++ b/package.json
@@ -14,17 +14,17 @@
     "preversion": "yarn run clean && yarn run refmt"
   },
   "peerDependencies": {
-    "bs-platform": "^2.2.2",
+    "bs-platform": "^3.0.0",
     "react-intl": "^2.4.0",
-    "reason-react": "^0.3.2"
+    "reason-react": "^0.4.1"
   },
   "devDependencies": {
-    "bs-platform": "2.2.2",
+    "bs-platform": "3.0.0",
     "prop-types": "15.6.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-intl": "2.4.0",
-    "reason-react": "0.3.2",
+    "reason-react": "0.4.1",
     "webpack": "3.10.0"
   },
   "repository": {

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -27,10 +27,6 @@ type defineMessages('m) = (. 'm) => 'm;
 external defineMessages : defineMessages(Js.t({..})) = "";
 
 /* Formatters */
-let mapOptBoolToJs = maybeBool =>
-  Js.Option.map((. bool) => bool |> Js.Boolean.to_js_boolean, maybeBool)
-  |> Js.Nullable.fromOption;
-
 type localeMatcher =
   | BestFitLocaleMatcher
   | LookupLocaleMatcher;
@@ -152,7 +148,7 @@ type dateTimeFormatOptionsJs = {
   "localeMatcher": Js.nullable(string),
   "formatMatcher": Js.nullable(string),
   "timeZone": Js.nullable(string),
-  "hour12": Js.nullable(Js.boolean),
+  "hour12": Js.nullable(bool),
   "weekday": Js.nullable(string),
   "era": Js.nullable(string),
   "year": Js.nullable(string),
@@ -171,7 +167,7 @@ let mapReasonDateTimeFormatOptionsToJs =
   "localeMatcher": options##localeMatcher |> mapReasonLocaleMatcherToJs,
   "formatMatcher": options##formatMatcher |> mapReasonFormatMatcherToJs,
   "timeZone": options##timeZone |> Js.Nullable.fromOption,
-  "hour12": options##hour12 |> mapOptBoolToJs,
+  "hour12": options##hour12 |> Js.Nullable.fromOption,
   "weekday": options##weekday |> mapReasonTextualFormatToJs,
   "era": options##era |> mapReasonTextualFormatToJs,
   "year": options##year |> mapReasonNumeralFormatToJs,
@@ -301,7 +297,7 @@ type numberFormatOptionsJs = {
   "style": Js.nullable(string),
   "currency": Js.nullable(string),
   "currencyDisplay": Js.nullable(string),
-  "useGrouping": Js.nullable(Js.boolean),
+  "useGrouping": Js.nullable(bool),
   "minimumIntegerDigits": Js.nullable(int),
   "minimumFractionDigits": Js.nullable(int),
   "maximumFractionDigits": Js.nullable(int),
@@ -314,7 +310,7 @@ let mapReasonNumberFormatOptionsToJs = options => {
   "style": options##style |> mapReasonNumberStyleToJs,
   "currency": options##currency |> Js.Nullable.fromOption,
   "currencyDisplay": options##currencyDisplay |> mapReasonCurrencyDisplayToJs,
-  "useGrouping": options##useGrouping |> mapOptBoolToJs,
+  "useGrouping": options##useGrouping |> Js.Nullable.fromOption,
   "minimumIntegerDigits":
     options##minimumIntegerDigits |> Js.Nullable.fromOption,
   "minimumFractionDigits":
@@ -651,7 +647,7 @@ module FormattedDate = {
         "localeMatcher": localeMatcher |> mapReasonLocaleMatcherToJs,
         "formatMatcher": formatMatcher |> mapReasonFormatMatcherToJs,
         "timeZone": timeZone |> Js.Nullable.fromOption,
-        "hour12": hour12 |> mapOptBoolToJs,
+        "hour12": hour12 |> Js.Nullable.fromOption,
         "weekday": weekday |> mapReasonTextualFormatToJs,
         "era": era |> mapReasonTextualFormatToJs,
         "year": year |> mapReasonNumeralFormatToJs,
@@ -696,7 +692,7 @@ module FormattedTime = {
         "localeMatcher": localeMatcher |> mapReasonLocaleMatcherToJs,
         "formatMatcher": formatMatcher |> mapReasonFormatMatcherToJs,
         "timeZone": timeZone |> Js.Nullable.fromOption,
-        "hour12": hour12 |> mapOptBoolToJs,
+        "hour12": hour12 |> Js.Nullable.fromOption,
         "weekday": weekday |> mapReasonTextualFormatToJs,
         "era": era |> mapReasonTextualFormatToJs,
         "year": year |> mapReasonNumeralFormatToJs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,9 +249,9 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-bs-platform@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.2.tgz#95ff37719771bbf310e8376fedd1148865c0da19"
+bs-platform@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.0.0.tgz#38f200730db52fdea37819376b6ac3dfb20244c0"
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -1668,9 +1668,9 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-reason-react@0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.3.2.tgz#14574b619bd9bf2b6057d681867a5dfa69f2360f"
+reason-react@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.4.1.tgz#f1c8bf0d116be6bf43109912ee4d95e58dd7c64f"
   dependencies:
     react ">=15.0.0 || >=16.0.0"
     react-dom ">=15.0.0 || >=16.0.0"


### PR DESCRIPTION
This is to get rid of all the deprecation warnings when using the latest bs-platform and reason-react.