### PR TITLE
Mention bs-react-intl-extractor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # bs-react-intl
 
-BuckleScript bindings to [react-intl](https://github.com/yahoo/react-intl).
+[BuckleScript](https://bucklescript.github.io) bindings to [react-intl](https://github.com/yahoo/react-intl).
+
+To extract messages from [Reason](https://reasonml.github.io) source files for localization, use [bs-react-intl-extractor](https://github.com/cknitt/bs-react-intl-extractor).
 
 ## Installation
 ```shell


### PR DESCRIPTION
Mention bs-react-intl-extractor in README and add links to BuckleScript and Reason.