### PR TITLE
Hooks api

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM](https://nodei.co/npm/bs-react-intl.png?compact=true)](https://nodei.co/npm/bs-react-intl/)
 
-[BuckleScript](https://bucklescript.github.io) bindings to [react-intl](https://github.com/yahoo/react-intl).
+[BuckleScript](https://bucklescript.github.io) bindings to [react-intl].
 
 To extract messages from [Reason](https://reasonml.github.io) source files for localization, use [bs-react-intl-extractor](https://github.com/cknitt/bs-react-intl-extractor).
 
@@ -24,29 +24,9 @@ yarn start
 ```
 
 ## Status
-Despite lots of unchecked the most hard work is done. I'll add bindings to the rest of the components once I need them. Feel free to help me out and submit a PR.
-
-- [x] addLocaleData
-- [x] intlShape
-- [x] injectIntl
-- [x] defineMessages
-- [x] IntlProvider
-- [x] FormattedDate
-- [ ] FormattedDate (children-as-function)
-- [x] FormattedTime
-- [ ] FormattedTime (children-as-function)
-- [ ] FormattedRelative
-- [ ] FormattedRelative (children-as-function)
-- [ ] FormattedNumber
-- [ ] FormattedNumber (children-as-function)
-- [ ] FormattedPlural
-- [ ] FormattedPlural (children-as-function)
-- [x] FormattedMessage
-- [ ] FormattedMessage (children-as-function)
-- [x] DefinedMessage
-- [ ] DefinedMessage (children-as-function)
-- [ ] FormattedHTMLMessage
-- [ ] FormattedHTMLMessage (children-as-function)
+bs-react-intl should cover all of the [react-intl] 3.0.0 API. If you find anything missing, please file an issue.
 
 ## Usage
 See [`examples`](./examples) folder.
+
+[react-intl]: https://github.com/formatjs/react-intl

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -10,12 +10,11 @@
   ],
   "bs-dependencies": ["reason-react"],
   "reason": {
-    "react-jsx": 2,
+    "react-jsx": 3,
   },
   "refmt": 3,
-  "bsc-flags": ["-bs-super-errors"],
   "package-specs": {
-    "module": "commonjs",
+    "module": "es6",
     "in-source": true,
   },
   "suffix": ".bs.js",

--- a/examples/App.re
+++ b/examples/App.re
@@ -14,7 +14,7 @@ let make = () => {
 
   <ReactIntl.IntlProvider
     locale={locale->Locale.toString}
-    messages={locale->Locale.toMessages->ReactIntl.messagesArrayToDict}>
+    messages={locale->Locale.translations->Util.translationsToDict}>
     <Page locale setLocale={locale => locale->SetLocale->dispatch} />
   </ReactIntl.IntlProvider>;
 };

--- a/examples/App.re
+++ b/examples/App.re
@@ -1,24 +1,20 @@
-type state = {locale: Locale.locale};
-
 type action =
   | SetLocale(Locale.locale);
 
-let component = ReasonReact.reducerComponent(__MODULE__);
+let initialState = Locale.En;
 
-let make = _ => {
-  ...component,
-  initialState: () => {locale: Locale.En},
-  reducer: (action, _) =>
-    switch (action) {
-    | SetLocale(locale) => ReasonReact.Update({locale: locale})
-    },
-  render: ({state, send}) =>
-    <ReactIntl.IntlProvider
-      locale=state.locale->Locale.toString
-      messages=state.locale->Locale.toMessages->ReactIntl.messagesArrayToDict>
-      <Page
-        locale={state.locale}
-        setLocale={locale => locale->SetLocale->send}
-      />
-    </ReactIntl.IntlProvider>,
+let reducer = (_, action) =>
+  switch (action) {
+  | SetLocale(locale) => locale
+  };
+
+[@react.component]
+let make = () => {
+  let (locale, dispatch) = reducer->React.useReducer(initialState);
+
+  <ReactIntl.IntlProvider
+    locale={locale->Locale.toString}
+    messages={locale->Locale.toMessages->ReactIntl.messagesArrayToDict}>
+    <Page locale setLocale={locale => locale->SetLocale->dispatch} />
+  </ReactIntl.IntlProvider>;
 };

--- a/examples/Locale.re
+++ b/examples/Locale.re
@@ -1,5 +1,7 @@
-[@bs.module] external en: ReactIntl.jsonMessages = "./translations/en.json";
-[@bs.module] external ru: ReactIntl.jsonMessages = "./translations/ru.json";
+[@bs.module "./translations/en.json"]
+external en: array(ReactIntl.translation) = "default";
+[@bs.module "./translations/ru.json"]
+external ru: array(ReactIntl.translation) = "default";
 
 type locale =
   | En
@@ -12,7 +14,7 @@ let toString =
   | En => "en"
   | Ru => "ru";
 
-let toMessages =
+let translations =
   fun
   | En => en
   | Ru => ru;

--- a/examples/Page.re
+++ b/examples/Page.re
@@ -1,45 +1,36 @@
 open PageLocale;
 
-let component = "Page" |> ReasonReact.statelessComponent;
-
-let make = (~locale, ~setLocale, _) => {
+[@react.component]
+let make = (~locale, ~setLocale) => {
+  let intl = ReactIntl.useIntl();
   let className = locale' => locale' === locale ? "active" : "";
 
-  {
-    ...component,
-    render: _ =>
-      <div className="container">
-        <div className="buttons">
-          <button
-            className=Locale.En->className onClick={_ => Locale.En->setLocale}>
-            Locale.En->Locale.toString->ReasonReact.string
-          </button>
-          <button
-            className=Locale.Ru->className onClick={_ => Locale.Ru->setLocale}>
-            Locale.Ru->Locale.toString->ReasonReact.string
-          </button>
-        </div>
-        <div className="message">
-          <ReactIntl.DefinedMessage message=pageLocale##hello />
-          " "->ReasonReact.string
-          <ReactIntl.DefinedMessage message=pageLocale##world />
-        </div>
-        <ReactIntl.IntlInjector>
-          ...{
-               intl =>
-                 <div>
-                   <ReactIntl.DefinedMessage message=pageLocale##today />
-                   " "->ReasonReact.string
-                   ()->Js.Date.make->(intl.formatDate)->ReasonReact.string
-                   " (intl.formatDate)"->ReasonReact.string
-                   <br />
-                   <ReactIntl.DefinedMessage message=pageLocale##today />
-                   " "->ReasonReact.string
-                   <ReactIntl.FormattedDate value={Js.Date.make()} />
-                   " (FormattedDate)"->ReasonReact.string
-                 </div>
-             }
-        </ReactIntl.IntlInjector>
-      </div>,
-  };
+  <div className="container">
+    <div className="buttons">
+      <button
+        className={Locale.En->className} onClick={_ => Locale.En->setLocale}>
+        {Locale.En->Locale.toString->React.string}
+      </button>
+      <button
+        className={Locale.Ru->className} onClick={_ => Locale.Ru->setLocale}>
+        {Locale.Ru->Locale.toString->React.string}
+      </button>
+    </div>
+    <div className="message">
+      <ReactIntl.DefinedMessage message=pageLocale##hello />
+      " "->React.string
+      <ReactIntl.DefinedMessage message=pageLocale##world />
+    </div>
+    <div>
+      <ReactIntl.DefinedMessage message=pageLocale##today />
+      " "->React.string
+      {intl.formatDate(Js.Date.make())->React.string}
+      " (intl.formatDate)"->React.string
+      <br />
+      <ReactIntl.DefinedMessage message=pageLocale##today />
+      " "->React.string
+      <ReactIntl.FormattedDate value={Js.Date.make()} />
+      " (FormattedDate)"->React.string
+    </div>
+  </div>;
 };

--- a/examples/Page.re
+++ b/examples/Page.re
@@ -17,17 +17,17 @@ let make = (~locale, ~setLocale) => {
       </button>
     </div>
     <div className="message">
-      <ReactIntl.DefinedMessage message=pageLocale##hello />
+      <ReactIntl.FormattedMessage id="page.hello" defaultMessage="Hello" />
       " "->React.string
-      <ReactIntl.DefinedMessage message=pageLocale##world />
+      <ReactIntl.FormattedMessage id="page.world" defaultMessage="World" />
     </div>
     <div>
-      <ReactIntl.DefinedMessage message=pageLocale##today />
+      ReactIntl.(intl->Intl.formatMessage(pageLocale##today)->React.string)
       " "->React.string
-      {intl.formatDate(Js.Date.make())->React.string}
+      ReactIntl.(intl->Intl.formatDate(Js.Date.make())->React.string)
       " (intl.formatDate)"->React.string
       <br />
-      <ReactIntl.DefinedMessage message=pageLocale##today />
+      ReactIntl.(intl->Intl.formatMessage(pageLocale##today)->React.string)
       " "->React.string
       <ReactIntl.FormattedDate value={Js.Date.make()} />
       " (FormattedDate)"->React.string

--- a/examples/Page.re
+++ b/examples/Page.re
@@ -1,3 +1,4 @@
+open ReactIntl;
 open PageLocale;
 
 [@react.component]
@@ -17,19 +18,19 @@ let make = (~locale, ~setLocale) => {
       </button>
     </div>
     <div className="message">
-      <ReactIntl.FormattedMessage id="page.hello" defaultMessage="Hello" />
+      <FormattedMessage id="page.hello" defaultMessage="Hello" />
       " "->React.string
-      <ReactIntl.FormattedMessage id="page.world" defaultMessage="World" />
+      <FormattedMessage id="page.world" defaultMessage="World" />
     </div>
     <div>
-      ReactIntl.(intl->Intl.formatMessage(pageLocale##today)->React.string)
+      {intl->Intl.formatMessage(pageLocale##today)->React.string}
       " "->React.string
-      ReactIntl.(intl->Intl.formatDate(Js.Date.make())->React.string)
+      {intl->Intl.formatDate(Js.Date.make())->React.string}
       " (intl.formatDate)"->React.string
       <br />
-      ReactIntl.(intl->Intl.formatMessage(pageLocale##today)->React.string)
+      {intl->Intl.formatMessage(pageLocale##today)->React.string}
       " "->React.string
-      <ReactIntl.FormattedDate value={Js.Date.make()} />
+      <FormattedDate value={Js.Date.make()} />
       " (FormattedDate)"->React.string
     </div>
   </div>;

--- a/examples/Util.re
+++ b/examples/Util.re
@@ -1,0 +1,22 @@
+let wrapUnicodeString = (input: string) => {j|$input|j};
+
+let wrapOptUnicodeString = (input: Js.nullable(string)) =>
+  switch (input->Js.Nullable.toOption) {
+  | Some(input) => input->wrapUnicodeString
+  | None => ""
+  };
+
+let translationsToDict = (translations: array(ReactIntl.translation)) => {
+  translations->Belt.Array.reduce(
+    Js.Dict.empty(),
+    (dict, message) => {
+      let unicodeMessage = message##message->wrapOptUnicodeString;
+      let unicodeDefaultMessage = message##defaultMessage->wrapUnicodeString;
+      dict->Js.Dict.set(
+        message##id,
+        unicodeMessage !== "" ? unicodeMessage : unicodeDefaultMessage,
+      );
+      dict;
+    },
+  );
+};

--- a/examples/Util.re
+++ b/examples/Util.re
@@ -1,20 +1,14 @@
-let wrapUnicodeString = (input: string) => {j|$input|j};
-
-let wrapOptUnicodeString = (input: Js.nullable(string)) =>
-  switch (input->Js.Nullable.toOption) {
-  | Some(input) => input->wrapUnicodeString
-  | None => ""
-  };
-
 let translationsToDict = (translations: array(ReactIntl.translation)) => {
   translations->Belt.Array.reduce(
     Js.Dict.empty(),
-    (dict, message) => {
-      let unicodeMessage = message##message->wrapOptUnicodeString;
-      let unicodeDefaultMessage = message##defaultMessage->wrapUnicodeString;
+    (dict, entry) => {
       dict->Js.Dict.set(
-        message##id,
-        unicodeMessage !== "" ? unicodeMessage : unicodeDefaultMessage,
+        entry##id,
+        switch (entry##message->Js.Nullable.toOption) {
+        | None
+        | Some("") => entry##defaultMessage
+        | Some(message) => message
+        },
       );
       dict;
     },

--- a/examples/index.re
+++ b/examples/index.re
@@ -1,9 +1,1 @@
-[@bs.module "react-intl/locale-data/en"]
-external en: ReactIntl.localeData('t) = "default";
-[@bs.module "react-intl/locale-data/ru"]
-external ru: ReactIntl.localeData('t) = "default";
-
-ReactIntl.addLocaleData(en);
-ReactIntl.addLocaleData(ru);
-
 ReactDOMRe.renderToElementWithId(<App />, "app");

--- a/examples/index.re
+++ b/examples/index.re
@@ -1,7 +1,7 @@
-[@bs.module]
-external en: ReactIntl.localeData('t) = "react-intl/locale-data/en";
-[@bs.module]
-external ru: ReactIntl.localeData('t) = "react-intl/locale-data/ru";
+[@bs.module "react-intl/locale-data/en"]
+external en: ReactIntl.localeData('t) = "default";
+[@bs.module "react-intl/locale-data/ru"]
+external ru: ReactIntl.localeData('t) = "default";
 
 ReactIntl.addLocaleData(en);
 ReactIntl.addLocaleData(ru);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-react-intl",
-  "version": "0.9.0-beta.1",
+  "version": "0.9.0-beta.2",
   "description": "BuckleScript bindings to react-intl",
   "author": "Alex Fedoseev <alex.fedoseev@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-intl": "2.8.0",
+    "react-intl": "3.0.0-beta-1",
     "reason-react": "0.7.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "bs-platform": "^5.0.3",
-    "react-intl": "^2.7.1",
+    "react-intl": "3.0.0-beta-8",
     "reason-react": "^0.7.0"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-intl": "3.0.0-beta-1",
+    "react-intl": "3.0.0-beta-8",
     "reason-react": "0.7.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-react-intl",
-  "version": "0.8.0",
+  "version": "0.9.0-beta.1",
   "description": "BuckleScript bindings to react-intl",
   "author": "Alex Fedoseev <alex.fedoseev@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "parcel examples/index.html",
     "build": "bsb -clean-world -make-world",
+    "watch": "bsb -clean-world -make-world -w",
     "clean": "bsb -clean-world",
     "extract": "node examples/TranslationsExtractor.bs.js",
     "preextract": "yarn run build",
@@ -16,12 +17,12 @@
     "preversion": "yarn run clean"
   },
   "peerDependencies": {
-    "bs-platform": "^5.0.0",
+    "bs-platform": "^5.0.3",
     "react-intl": "^2.7.1",
-    "reason-react": "^0.5.3"
+    "reason-react": "^0.7.0"
   },
   "devDependencies": {
-    "bs-platform": "5.0.0",
+    "bs-platform": "5.0.3",
     "bs-react-intl-extractor-bin": "0.7.0",
     "bsb-js": "^1.1.7",
     "parcel-bundler": "1.12.3",
@@ -29,7 +30,7 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-intl": "2.8.0",
-    "reason-react": "0.6.0"
+    "reason-react": "0.7.0"
   },
   "repository": {
     "type": "git",

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -82,6 +82,13 @@ type message = {
   "defaultMessage": string,
 };
 
+type translation = {
+  .
+  "id": string,
+  "defaultMessage": string,
+  "message": Js.nullable(string),
+};
+
 module Intl = {
   type t;
 
@@ -124,9 +131,13 @@ module Intl = {
   [@bs.send] external now: (t, unit) => int = "";
 };
 
-type intl = Intl.t;
+[@bs.val] [@bs.module "react-intl"]
+external context: React.Context.t(Intl.t) = "IntlContext";
 
-[@bs.module "react-intl"] external useIntl: unit => intl = "";
+// Not in react-intl yet
+// [@bs.module "react-intl"] external useIntl: unit => intl = "";
+
+let useIntl = () => context->React.useContext; // not zero-cost but will be when react-intl will add it
 
 type textComponent;
 

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -1,7 +1,3 @@
-type localeData('t) = {.. "locale": string} as 't;
-
-[@bs.module "react-intl"] external addLocaleData: localeData('t) => unit = "";
-
 type dateTimeFormatOptions;
 
 [@bs.obj]
@@ -134,10 +130,7 @@ module Intl = {
 [@bs.val] [@bs.module "react-intl"]
 external context: React.Context.t(Intl.t) = "IntlContext";
 
-// Not in react-intl yet
-// [@bs.module "react-intl"] external useIntl: unit => intl = "";
-
-let useIntl = () => context->React.useContext; // not zero-cost but will be when react-intl will add it
+[@bs.module "react-intl"] external useIntl: unit => Intl.t = "";
 
 type textComponent;
 

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -38,8 +38,7 @@ let mapReasonLocaleMatcherToJs = localeMatcher =>
       | LookupLocaleMatcher => "lookup"
       },
     localeMatcher,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type formatMatcher =
   | BestFitFormatMatcher
@@ -53,8 +52,7 @@ let mapReasonFormatMatcherToJs = formatMatcher =>
       | BasicFormatMatcher => "basic"
       },
     formatMatcher,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type numeralFormat =
   | NumericNumeralFormat
@@ -68,8 +66,7 @@ let mapReasonNumeralFormatToJs = numeralFormat =>
       | TwoDigitNumeralFormat => "2-digit"
       },
     numeralFormat,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type textualFormat =
   | NarrowTextualFormat
@@ -85,8 +82,7 @@ let mapReasonTextualFormatToJs = textualFormat =>
       | LongTextualFormat => "long"
       },
     textualFormat,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type mixedFormat =
   | NumericMixedFormat
@@ -106,8 +102,7 @@ let mapReasonMixedFormatToJs = mixedFormat =>
       | TwoDigitMixedFormat => "2-digit"
       },
     mixedFormat,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type timeZoneName =
   | ShortTimeZoneName
@@ -121,8 +116,7 @@ let mapReasonTimeZoneNameToJs = timeZoneName =>
       | LongTimeZoneName => "long"
       },
     timeZoneName,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type dateTimeFormatOptionsRe = {
   .
@@ -144,38 +138,38 @@ type dateTimeFormatOptionsRe = {
 
 type dateTimeFormatOptionsJs = {
   .
-  "localeMatcher": Js.nullable(string),
-  "formatMatcher": Js.nullable(string),
-  "timeZone": Js.nullable(string),
-  "hour12": Js.nullable(bool),
-  "weekday": Js.nullable(string),
-  "era": Js.nullable(string),
-  "year": Js.nullable(string),
-  "month": Js.nullable(string),
-  "day": Js.nullable(string),
-  "hour": Js.nullable(string),
-  "minute": Js.nullable(string),
-  "second": Js.nullable(string),
-  "timeZoneName": Js.nullable(string),
-  "format": Js.nullable(string),
+  "localeMatcher": option(string),
+  "formatMatcher": option(string),
+  "timeZone": option(string),
+  "hour12": option(bool),
+  "weekday": option(string),
+  "era": option(string),
+  "year": option(string),
+  "month": option(string),
+  "day": option(string),
+  "hour": option(string),
+  "minute": option(string),
+  "second": option(string),
+  "timeZoneName": option(string),
+  "format": option(string),
 };
 
 let mapReasonDateTimeFormatOptionsToJs =
     (options: dateTimeFormatOptionsRe): dateTimeFormatOptionsJs => {
-  "localeMatcher": options##localeMatcher |> mapReasonLocaleMatcherToJs,
-  "formatMatcher": options##formatMatcher |> mapReasonFormatMatcherToJs,
-  "timeZone": options##timeZone |> Js.Nullable.fromOption,
-  "hour12": options##hour12 |> Js.Nullable.fromOption,
-  "weekday": options##weekday |> mapReasonTextualFormatToJs,
-  "era": options##era |> mapReasonTextualFormatToJs,
-  "year": options##year |> mapReasonNumeralFormatToJs,
-  "month": options##month |> mapReasonMixedFormatToJs,
-  "day": options##day |> mapReasonNumeralFormatToJs,
-  "hour": options##hour |> mapReasonNumeralFormatToJs,
-  "minute": options##minute |> mapReasonNumeralFormatToJs,
-  "second": options##second |> mapReasonNumeralFormatToJs,
-  "timeZoneName": options##timeZoneName |> mapReasonTimeZoneNameToJs,
-  "format": options##format |> Js.Nullable.fromOption,
+  "localeMatcher": options##localeMatcher->mapReasonLocaleMatcherToJs,
+  "formatMatcher": options##formatMatcher->mapReasonFormatMatcherToJs,
+  "timeZone": options##timeZone,
+  "hour12": options##hour12,
+  "weekday": options##weekday->mapReasonTextualFormatToJs,
+  "era": options##era->mapReasonTextualFormatToJs,
+  "year": options##year->mapReasonNumeralFormatToJs,
+  "month": options##month->mapReasonMixedFormatToJs,
+  "day": options##day->mapReasonNumeralFormatToJs,
+  "hour": options##hour->mapReasonNumeralFormatToJs,
+  "minute": options##minute->mapReasonNumeralFormatToJs,
+  "second": options##second->mapReasonNumeralFormatToJs,
+  "timeZoneName": options##timeZoneName->mapReasonTimeZoneNameToJs,
+  "format": options##format,
 };
 
 type relativeStyle =
@@ -190,8 +184,7 @@ let mapReasonRelativeStyleToJs = relativeStyle =>
       | NumericRelativeStyle => "numeric"
       },
     relativeStyle,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type units =
   | Second
@@ -213,8 +206,7 @@ let mapReasonUnitsToJs = units =>
       | Year => "year"
       },
     units,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type relativeFormatOptionsRe = {
   .
@@ -226,18 +218,18 @@ type relativeFormatOptionsRe = {
 
 type relativeFormatOptionsJs = {
   .
-  "style": Js.nullable(string),
-  "units": Js.nullable(string),
-  "format": Js.nullable(string),
-  "now": Js.nullable(int),
+  "style": option(string),
+  "units": option(string),
+  "format": option(string),
+  "now": option(int),
 };
 
 let mapReasonRelativeFormatOptionsToJs =
     (options: relativeFormatOptionsRe): relativeFormatOptionsJs => {
-  "style": options##style |> mapReasonRelativeStyleToJs,
-  "units": options##units |> mapReasonUnitsToJs,
-  "format": options##format |> Js.Nullable.fromOption,
-  "now": options##now |> Js.Nullable.fromOption,
+  "style": options##style->mapReasonRelativeStyleToJs,
+  "units": options##units->mapReasonUnitsToJs,
+  "format": options##format,
+  "now": options##now,
 };
 
 type numberStyle =
@@ -254,8 +246,7 @@ let mapReasonNumberStyleToJs = numberStyle =>
       | PercentNumberStyle => "percent"
       },
     numberStyle,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type currencyDisplay =
   | SymbolCurrencyDisplay
@@ -271,8 +262,7 @@ let mapReasonCurrencyDisplayToJs = currencyDisplay =>
       | NameCurrencyDisplay => "name"
       },
     currencyDisplay,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type numberFormatOptionsRe = {
   .
@@ -290,34 +280,30 @@ type numberFormatOptionsRe = {
 
 type numberFormatOptionsJs = {
   .
-  "localeMatcher": Js.nullable(string),
-  "style": Js.nullable(string),
-  "currency": Js.nullable(string),
-  "currencyDisplay": Js.nullable(string),
-  "useGrouping": Js.nullable(bool),
-  "minimumIntegerDigits": Js.nullable(int),
-  "minimumFractionDigits": Js.nullable(int),
-  "maximumFractionDigits": Js.nullable(int),
-  "minimumSignificantDigits": Js.nullable(int),
-  "maximumSignificantDigits": Js.nullable(int),
+  "localeMatcher": option(string),
+  "style": option(string),
+  "currency": option(string),
+  "currencyDisplay": option(string),
+  "useGrouping": option(bool),
+  "minimumIntegerDigits": option(int),
+  "minimumFractionDigits": option(int),
+  "maximumFractionDigits": option(int),
+  "minimumSignificantDigits": option(int),
+  "maximumSignificantDigits": option(int),
 };
 
-let mapReasonNumberFormatOptionsToJs = options => {
-  "localeMatcher": options##localeMatcher |> mapReasonLocaleMatcherToJs,
-  "style": options##style |> mapReasonNumberStyleToJs,
-  "currency": options##currency |> Js.Nullable.fromOption,
-  "currencyDisplay": options##currencyDisplay |> mapReasonCurrencyDisplayToJs,
-  "useGrouping": options##useGrouping |> Js.Nullable.fromOption,
-  "minimumIntegerDigits":
-    options##minimumIntegerDigits |> Js.Nullable.fromOption,
-  "minimumFractionDigits":
-    options##minimumFractionDigits |> Js.Nullable.fromOption,
-  "maximumFractionDigits":
-    options##maximumFractionDigits |> Js.Nullable.fromOption,
-  "minimumSignificantDigits":
-    options##minimumSignificantDigits |> Js.Nullable.fromOption,
-  "maximumSignificantDigits":
-    options##maximumSignificantDigits |> Js.Nullable.fromOption,
+let mapReasonNumberFormatOptionsToJs =
+    (options: numberFormatOptionsRe): numberFormatOptionsJs => {
+  "localeMatcher": options##localeMatcher->mapReasonLocaleMatcherToJs,
+  "style": options##style->mapReasonNumberStyleToJs,
+  "currency": options##currency,
+  "currencyDisplay": options##currencyDisplay->mapReasonCurrencyDisplayToJs,
+  "useGrouping": options##useGrouping,
+  "minimumIntegerDigits": options##minimumIntegerDigits,
+  "minimumFractionDigits": options##minimumFractionDigits,
+  "maximumFractionDigits": options##maximumFractionDigits,
+  "minimumSignificantDigits": options##minimumSignificantDigits,
+  "maximumSignificantDigits": options##maximumSignificantDigits,
 };
 
 type pluralStyle =
@@ -332,15 +318,14 @@ let mapReasonPluralStyleToJs = pluralStyle =>
       | OrdinalPluralStyle => "ordinal"
       },
     pluralStyle,
-  )
-  |> Js.Nullable.fromOption;
+  );
 
 type pluralFormatOptionsRe = {. "style": option(pluralStyle)};
 
-type pluralFormatOptionsJs = {. "style": Js.nullable(string)};
+type pluralFormatOptionsJs = {. "style": option(string)};
 
 let mapReasonPluralFormatOptionsToJs = options => {
-  "style": options##style |> mapReasonPluralStyleToJs,
+  "style": options##style->mapReasonPluralStyleToJs,
 };
 
 /* Components */
@@ -365,9 +350,9 @@ type domTag =
   | Sub
   | Sup;
 
-type textComponent =
+type textComponent('props) =
   | DomTag(domTag)
-  | ReactComponent(ReasonReact.reactClass);
+  | ReactComponent(React.component('props));
 
 let mapDomTagToString = tag =>
   switch (tag) {
@@ -394,13 +379,13 @@ let mapDomTagToString = tag =>
 
 let mapOptDomTagToString = tag =>
   switch (tag) {
-  | Some(tag) => Some(tag |> mapDomTagToString)
+  | Some(tag) => Some(tag->mapDomTagToString)
   | None => None
   };
 
 let mapTextComponentToJs = textComponent =>
   switch (textComponent) {
-  | DomTag(domTag) => mapDomTagToString(domTag)->Obj.magic
+  | DomTag(domTag) => domTag->mapDomTagToString->Obj.magic
   | ReactComponent(reactComponent) => reactComponent->Obj.magic
   };
 
@@ -410,35 +395,66 @@ let mapOptTextComponentToJs = textComponent =>
 type errorHandler = string => unit;
 
 module IntlProvider = {
-  [@bs.module "react-intl"]
-  external reactClass: ReasonReact.reactClass = "IntlProvider";
-  let make =
+  type props('a, 'b) = {
+    .
+    "locale": option(string),
+    "formats": option(Js.t({..} as 'a)), /* TODO */
+    "messages": option(Js.Dict.t(string)),
+    "defaultLocale": option(string),
+    "defaultFormats": option(Js.t({..} as 'a)), /* TODO */
+    "textComponent": option(textComponent('b)),
+    "initialNow": option(int),
+    "onError": option(errorHandler),
+  };
+
+  [@bs.obj]
+  external makeProps:
+    (
+      ~locale: string=?,
+      ~formats: Js.t({..} as 'a)=?, /* TODO */
+      ~messages: Js.Dict.t(string)=?,
+      ~defaultLocale: string=?,
+      ~defaultFormats: Js.t({..} as 'a)=?, /* TODO */
+      ~textComponent: option(textComponent('b))=?,
+      ~initialNow: int=?,
+      ~onError: errorHandler=?,
+      ~children: React.element,
+      ~key: string=?,
+      unit
+    ) =>
+    props('a, 'b) =
+    "";
+
+  let makeProps =
       (
-        ~locale: option(string)=?,
-        ~formats: option(Js.t({..}))=?, /* TODO */
-        ~messages: option(Js.Dict.t(string))=?,
-        ~defaultLocale: option(string)=?,
-        ~defaultFormats: option(Js.t({..}))=?, /* TODO */
-        ~textComponent: option(textComponent)=?,
-        ~initialNow: option(int)=?,
-        ~onError: option(errorHandler)=?,
-        children,
+        ~locale=?,
+        ~formats=?,
+        ~messages=?,
+        ~defaultLocale=?,
+        ~defaultFormats=?,
+        ~textComponent=?,
+        ~initialNow=?,
+        ~onError=?,
+        ~children,
+        ~key=?,
+        (),
       ) =>
-    ReasonReact.wrapJsForReason(
-      ~reactClass,
-      ~props={
-        "locale": locale |> Js.Nullable.fromOption,
-        "formats": formats |> Js.Nullable.fromOption,
-        "messages": messages |> Js.Nullable.fromOption,
-        "defaultLocale": defaultLocale |> Js.Nullable.fromOption,
-        "defaultFormats": defaultFormats |> Js.Nullable.fromOption,
-        "textComponent":
-          textComponent |> mapOptTextComponentToJs |> Js.Nullable.fromOption,
-        "initialNow": initialNow |> Js.Nullable.fromOption,
-        "onError": onError |> Js.Nullable.fromOption,
-      },
-      children,
+    makeProps(
+      ~locale?,
+      ~formats?,
+      ~messages?,
+      ~defaultLocale?,
+      ~defaultFormats?,
+      ~textComponent=?textComponent->mapOptTextComponentToJs,
+      ~initialNow?,
+      ~onError?,
+      ~children,
+      ~key?,
+      (),
     );
+
+  [@bs.module "react-intl"]
+  external make: React.component(props('a, 'b)) = "IntlProvider";
 };
 
 type intlJs('t) =
@@ -451,24 +467,24 @@ type intlJs('t) =
     "defaultFormats": Js.t({..}), /* TODO */
     "formatDate":
       [@bs.meth] (
-        (Js.Date.t, Js.nullable(dateTimeFormatOptionsJs)) => string
+        (Js.Date.t, Js.undefined(dateTimeFormatOptionsJs)) => string
       ),
     "formatTime":
       [@bs.meth] (
-        (Js.Date.t, Js.nullable(dateTimeFormatOptionsJs)) => string
+        (Js.Date.t, Js.undefined(dateTimeFormatOptionsJs)) => string
       ),
     "formatRelative":
       [@bs.meth] (
-        (Js.Date.t, Js.nullable(relativeFormatOptionsJs)) => string
+        (Js.Date.t, Js.undefined(relativeFormatOptionsJs)) => string
       ),
     "formatNumber":
-      [@bs.meth] ((float, Js.nullable(numberFormatOptionsJs)) => string),
+      [@bs.meth] ((float, Js.undefined(numberFormatOptionsJs)) => string),
     "formatPlural":
-      [@bs.meth] ((int, Js.nullable(pluralFormatOptionsJs)) => string),
+      [@bs.meth] ((int, Js.undefined(pluralFormatOptionsJs)) => string),
     "formatMessage":
-      [@bs.meth] ((message, Js.nullable(Js.t({..}))) => string),
+      [@bs.meth] ((message, Js.undefined(Js.t({..}))) => string),
     "formatHTMLMessage":
-      [@bs.meth] ((message, Js.nullable(Js.t({..}))) => string),
+      [@bs.meth] ((message, Js.undefined(Js.t({..}))) => string),
     "now": [@bs.meth] (unit => int),
   } as 't;
 
@@ -503,138 +519,158 @@ let mapIntlJsToReason = (intlJs: intlJs('t)): intl('a) => {
   messages: intlJs##messages,
   defaultLocale: intlJs##defaultLocale,
   defaultFormats: intlJs##defaultFormats,
-  formatDate: value =>
-    intlJs##formatDate(value, None |> Js.Nullable.fromOption),
+  formatDate: value => intlJs##formatDate(value, Js.undefined),
   formatDateWithOptions: (options, value) =>
     intlJs##formatDate(
       value,
-      Some(options |> mapReasonDateTimeFormatOptionsToJs)
-      |> Js.Nullable.fromOption,
+      Some(options->mapReasonDateTimeFormatOptionsToJs)
+      ->Js.Undefined.fromOption,
     ),
-  formatTime: value =>
-    intlJs##formatTime(value, None |> Js.Nullable.fromOption),
+  formatTime: value => intlJs##formatTime(value, Js.undefined),
   formatTimeWithOptions: (options, value) =>
     intlJs##formatTime(
       value,
-      Some(options |> mapReasonDateTimeFormatOptionsToJs)
-      |> Js.Nullable.fromOption,
+      Some(options->mapReasonDateTimeFormatOptionsToJs)
+      ->Js.Undefined.fromOption,
     ),
-  formatRelative: value =>
-    intlJs##formatRelative(value, None |> Js.Nullable.fromOption),
+  formatRelative: value => intlJs##formatRelative(value, Js.undefined),
   formatRelativeWithOptions: (options, value) =>
     intlJs##formatRelative(
       value,
-      Some(options |> mapReasonRelativeFormatOptionsToJs)
-      |> Js.Nullable.fromOption,
+      Some(options->mapReasonRelativeFormatOptionsToJs)
+      ->Js.Undefined.fromOption,
     ),
-  formatInt: value =>
-    intlJs##formatNumber(
-      value |> float_of_int,
-      None |> Js.Nullable.fromOption,
-    ),
+  formatInt: value => intlJs##formatNumber(value->float_of_int, Js.undefined),
   formatIntWithOptions: (options, value) =>
     intlJs##formatNumber(
-      value |> float_of_int,
-      Some(options |> mapReasonNumberFormatOptionsToJs)
-      |> Js.Nullable.fromOption,
+      value->float_of_int,
+      Some(options->mapReasonNumberFormatOptionsToJs)
+      ->Js.Undefined.fromOption,
     ),
-  formatFloat: value =>
-    intlJs##formatNumber(value, None |> Js.Nullable.fromOption),
+  formatFloat: value => intlJs##formatNumber(value, Js.undefined),
   formatFloatWithOptions: (options, value) =>
     intlJs##formatNumber(
       value,
-      Some(options |> mapReasonNumberFormatOptionsToJs)
-      |> Js.Nullable.fromOption,
+      Some(options->mapReasonNumberFormatOptionsToJs)
+      ->Js.Undefined.fromOption,
     ),
-  formatPlural: value =>
-    intlJs##formatPlural(value, None |> Js.Nullable.fromOption),
+  formatPlural: value => intlJs##formatPlural(value, Js.undefined),
   formatPluralWithOptions: (options, value) =>
     intlJs##formatPlural(
       value,
-      Some(options |> mapReasonPluralFormatOptionsToJs)
-      |> Js.Nullable.fromOption,
+      Some(options->mapReasonPluralFormatOptionsToJs)
+      ->Js.Undefined.fromOption,
     ),
-  formatMessage: message =>
-    intlJs##formatMessage(message, None |> Js.Nullable.fromOption),
+  formatMessage: message => intlJs##formatMessage(message, Js.undefined),
   formatMessageWithValues: (values, message) =>
-    intlJs##formatMessage(message, Some(values) |> Js.Nullable.fromOption),
+    intlJs##formatMessage(message, Some(values)->Js.Undefined.fromOption),
   formatHTMLMessage: message =>
-    intlJs##formatHTMLMessage(message, None |> Js.Nullable.fromOption),
+    intlJs##formatHTMLMessage(message, Js.undefined),
   formatHTMLMessageWithValues: (values, message) =>
     intlJs##formatHTMLMessage(
       message,
-      Some(values) |> Js.Nullable.fromOption,
+      Some(values)->Js.Undefined.fromOption,
     ),
   now: () => intlJs##now(),
 };
 
-module IntlInjector = {
-  let reactClass: ReasonReact.reactClass = [%bs.raw
-    {|
-    require("react-intl").injectIntl(function(_ref) {
-      var intl = _ref.intl, children = _ref.children;
-      return children(intl);
-    })
-    |}
-  ];
-  let make = children =>
-    ReasonReact.wrapJsForReason(
-      ~reactClass, ~props=Js.Obj.empty(), (intlJs: intlJs('t)) =>
-      children(mapIntlJsToReason(intlJs))
-    );
-};
+[@bs.module "react-intl"] external useIntl: unit => intlJs('t) = "useIntl";
+let useIntl = () => useIntl()->mapIntlJsToReason;
 
 module FormattedMessage = {
-  [@bs.module "react-intl"]
-  external reactClass: ReasonReact.reactClass = "FormattedMessage";
-  let make =
-      (
-        ~id: string,
-        ~defaultMessage: string,
-        ~values: option(Js.t({..}))=?,
-        ~tagName: option(domTag)=?,
-        _,
-      ) =>
-    ReasonReact.wrapJsForReason(
-      ~reactClass,
-      ~props={
-        "id": id,
-        "defaultMessage": defaultMessage,
-        "values": values |> Js.Nullable.fromOption,
-        "tagName": tagName |> mapOptDomTagToString |> Js.Nullable.fromOption,
-      },
-      [||],
-    );
+  [@bs.module "react-intl"] [@react.component]
+  external make:
+    (
+      ~id: string,
+      ~defaultMessage: string,
+      ~values: Js.t({..}) as 'a=?,
+      ~tagName: [@bs.string] [
+                  | `span
+                  | `div
+                  | `p
+                  | `h1
+                  | `h2
+                  | `h3
+                  | `h4
+                  | `h5
+                  | `h6
+                  | `strong
+                  | `b
+                  | `i
+                  | `em
+                  | `mark
+                  | `small
+                  | `del
+                  | `ins
+                  | `sub
+                  | `sup
+                ]
+                  =?
+    ) =>
+    React.element =
+    "FormattedMessage";
 };
 
-/* DefinedMessage is another wrapper for FormattedMessage.
-   It takes the id and defaultMessage props from a passed message object. */
+// DefinedMessage is another wrapper for FormattedMessage.
+// It takes the id and defaultMessage props from a passed message object.
 module DefinedMessage = {
-  [@bs.module "react-intl"]
-  external reactClass: ReasonReact.reactClass = "FormattedMessage";
-  let make =
-      (
-        ~message: message,
-        ~values: option(Js.t({..}))=?,
-        ~tagName: option(domTag)=?,
-        _,
-      ) =>
-    ReasonReact.wrapJsForReason(
-      ~reactClass,
-      ~props={
-        "id": message##id,
-        "defaultMessage": message##defaultMessage,
-        "values": values |> Js.Nullable.fromOption,
-        "tagName": tagName |> mapOptDomTagToString |> Js.Nullable.fromOption,
-      },
-      [||],
+  let make = FormattedMessage.make;
+  let makeProps = (~message: message, ~values=?, ~tagName=?, ~key=?, ()) =>
+    FormattedMessage.makeProps(
+      ~id=message##id,
+      ~defaultMessage=message##defaultMessage,
+      ~values?,
+      ~tagName?,
+      ~key?,
+      (),
     );
 };
 
 module FormattedDate = {
-  [@bs.module "react-intl"]
-  external reactClass: ReasonReact.reactClass = "FormattedDate";
-  let make =
+  type props = {
+    .
+    "value": Js.Date.t,
+    "format": option(string),
+    "localeMatcher": option(string),
+    "formatMatcher": option(string),
+    "timeZone": option(string),
+    "hour12": option(bool),
+    "weekday": option(string),
+    "era": option(string),
+    "year": option(string),
+    "month": option(string),
+    "day": option(string),
+    "hour": option(string),
+    "minute": option(string),
+    "second": option(string),
+    "timeZoneName": option(string),
+  };
+
+  [@bs.obj]
+  external makeProps:
+    (
+      ~value: Js.Date.t,
+      ~format: string=?,
+      ~localeMatcher: string=?,
+      ~formatMatcher: string=?,
+      ~timeZone: string=?,
+      ~hour12: bool=?,
+      ~weekday: string=?,
+      ~era: string=?,
+      ~year: string=?,
+      ~month: string=?,
+      ~day: string=?,
+      ~hour: string=?,
+      ~minute: string=?,
+      ~second: string=?,
+      ~timeZoneName: string=?,
+      ~key: string=?,
+      unit
+    ) =>
+    props =
+    "";
+
+  let makeProps =
       (
         ~value: Js.Date.t,
         ~format: option(string)=?,
@@ -651,35 +687,78 @@ module FormattedDate = {
         ~minute: option(numeralFormat)=?,
         ~second: option(numeralFormat)=?,
         ~timeZoneName: option(timeZoneName)=?,
-        _,
+        ~key=?,
+        (),
       ) =>
-    ReasonReact.wrapJsForReason(
-      ~reactClass,
-      ~props={
-        "value": value,
-        "format": format |> Js.Nullable.fromOption,
-        "localeMatcher": localeMatcher |> mapReasonLocaleMatcherToJs,
-        "formatMatcher": formatMatcher |> mapReasonFormatMatcherToJs,
-        "timeZone": timeZone |> Js.Nullable.fromOption,
-        "hour12": hour12 |> Js.Nullable.fromOption,
-        "weekday": weekday |> mapReasonTextualFormatToJs,
-        "era": era |> mapReasonTextualFormatToJs,
-        "year": year |> mapReasonNumeralFormatToJs,
-        "month": month |> mapReasonMixedFormatToJs,
-        "day": day |> mapReasonNumeralFormatToJs,
-        "hour": hour |> mapReasonNumeralFormatToJs,
-        "minute": minute |> mapReasonNumeralFormatToJs,
-        "second": second |> mapReasonNumeralFormatToJs,
-        "timeZoneName": timeZoneName |> mapReasonTimeZoneNameToJs,
-      },
-      [||],
+    makeProps(
+      ~value,
+      ~format?,
+      ~localeMatcher=?localeMatcher->mapReasonLocaleMatcherToJs,
+      ~formatMatcher=?formatMatcher->mapReasonFormatMatcherToJs,
+      ~timeZone?,
+      ~hour12?,
+      ~weekday=?weekday->mapReasonTextualFormatToJs,
+      ~era=?era->mapReasonTextualFormatToJs,
+      ~year=?year->mapReasonNumeralFormatToJs,
+      ~month=?month->mapReasonMixedFormatToJs,
+      ~day=?day->mapReasonNumeralFormatToJs,
+      ~hour=?hour->mapReasonNumeralFormatToJs,
+      ~minute=?minute->mapReasonNumeralFormatToJs,
+      ~second=?second->mapReasonNumeralFormatToJs,
+      ~timeZoneName=?timeZoneName->mapReasonTimeZoneNameToJs,
+      ~key?,
+      (),
     );
+
+  [@bs.module "react-intl"]
+  external make: React.component(props) = "FormattedDate";
 };
 
 module FormattedTime = {
-  [@bs.module "react-intl"]
-  external reactClass: ReasonReact.reactClass = "FormattedTime";
-  let make =
+  type props = {
+    .
+    "value": Js.Date.t,
+    "format": option(string),
+    "localeMatcher": option(string),
+    "formatMatcher": option(string),
+    "timeZone": option(string),
+    "hour12": option(bool),
+    "weekday": option(string),
+    "era": option(string),
+    "year": option(string),
+    "month": option(string),
+    "day": option(string),
+    "hour": option(string),
+    "minute": option(string),
+    "second": option(string),
+    "timeZoneName": option(string),
+  };
+
+  [@bs.obj]
+  external makeProps:
+    (
+      ~value: Js.Date.t,
+      ~format: string=?,
+      ~localeMatcher: string=?,
+      ~formatMatcher: string=?,
+      ~timeZone: string=?,
+      ~hour12: bool=?,
+      ~weekday: string=?,
+      ~era: string=?,
+      ~year: string=?,
+      ~month: string=?,
+      ~day: string=?,
+      ~hour: string=?,
+      ~minute: string=?,
+      ~second: string=?,
+      ~timeZoneName: string=?,
+      ~key: string=?,
+      unit
+    ) =>
+    props =
+    "";
+
+  let makeProps =
       (
         ~value: Js.Date.t,
         ~format: option(string)=?,
@@ -696,53 +775,53 @@ module FormattedTime = {
         ~minute: option(numeralFormat)=?,
         ~second: option(numeralFormat)=?,
         ~timeZoneName: option(timeZoneName)=?,
-        _,
+        ~key=?,
+        (),
       ) =>
-    ReasonReact.wrapJsForReason(
-      ~reactClass,
-      ~props={
-        "value": value,
-        "format": format |> Js.Nullable.fromOption,
-        "localeMatcher": localeMatcher |> mapReasonLocaleMatcherToJs,
-        "formatMatcher": formatMatcher |> mapReasonFormatMatcherToJs,
-        "timeZone": timeZone |> Js.Nullable.fromOption,
-        "hour12": hour12 |> Js.Nullable.fromOption,
-        "weekday": weekday |> mapReasonTextualFormatToJs,
-        "era": era |> mapReasonTextualFormatToJs,
-        "year": year |> mapReasonNumeralFormatToJs,
-        "month": month |> mapReasonMixedFormatToJs,
-        "day": day |> mapReasonNumeralFormatToJs,
-        "hour": hour |> mapReasonNumeralFormatToJs,
-        "minute": minute |> mapReasonNumeralFormatToJs,
-        "second": second |> mapReasonNumeralFormatToJs,
-        "timeZoneName": timeZoneName |> mapReasonTimeZoneNameToJs,
-      },
-      [||],
+    makeProps(
+      ~value,
+      ~format?,
+      ~localeMatcher=?localeMatcher->mapReasonLocaleMatcherToJs,
+      ~formatMatcher=?formatMatcher->mapReasonFormatMatcherToJs,
+      ~timeZone?,
+      ~hour12?,
+      ~weekday=?weekday->mapReasonTextualFormatToJs,
+      ~era=?era->mapReasonTextualFormatToJs,
+      ~year=?year->mapReasonNumeralFormatToJs,
+      ~month=?month->mapReasonMixedFormatToJs,
+      ~day=?day->mapReasonNumeralFormatToJs,
+      ~hour=?hour->mapReasonNumeralFormatToJs,
+      ~minute=?minute->mapReasonNumeralFormatToJs,
+      ~second=?second->mapReasonNumeralFormatToJs,
+      ~timeZoneName=?timeZoneName->mapReasonTimeZoneNameToJs,
+      ~key?,
+      (),
     );
+
+  [@bs.module "react-intl"]
+  external make: React.component(props) = "FormattedDate";
 };
 
 /* Utils */
 let wrapUnicodeString = (input: string) => {j|$input|j};
 
 let wrapOptUnicodeString = (input: Js.nullable(string)) =>
-  switch (input |> Js.Nullable.toOption) {
-  | Some(input) => input |> wrapUnicodeString
+  switch (input->Js.Nullable.toOption) {
+  | Some(input) => input->wrapUnicodeString
   | None => ""
   };
 
 let messagesArrayToDict = (translation: jsonMessages) =>
-  translation
-  |> Array.fold_left(
-       (dict, message) => {
-         let unicodeMessage = message##message |> wrapOptUnicodeString;
-         let unicodeDefaultMessage =
-           message##defaultMessage |> wrapUnicodeString;
-         Js.Dict.set(
-           dict,
-           message##id,
-           unicodeMessage !== "" ? unicodeMessage : unicodeDefaultMessage,
-         );
-         dict;
-       },
-       Js.Dict.empty(),
-     );
+  translation->Belt.Array.reduce(
+    Js.Dict.empty(),
+    (dict, message) => {
+      let unicodeMessage = message##message->wrapOptUnicodeString;
+      let unicodeDefaultMessage = message##defaultMessage->wrapUnicodeString;
+      Js.Dict.set(
+        dict,
+        message##id,
+        unicodeMessage !== "" ? unicodeMessage : unicodeDefaultMessage,
+      );
+      dict;
+    },
+  );

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -1,827 +1,312 @@
-/* Common */
+type localeData('t) = {.. "locale": string} as 't;
+
+[@bs.module "react-intl"] external addLocaleData: localeData('t) => unit = "";
+
+type dateTimeFormatOptions;
+
+[@bs.obj]
+external dateTimeFormatOptions:
+  (
+    ~localeMatcher: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `lookup]=?,
+    ~formatMatcher: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `basic]=?,
+    ~timeZone: string=?,
+    ~hour12: bool=?,
+    ~weekday: [@bs.string] [ | `narrow | `short | `long]=?,
+    ~era: [@bs.string] [ | `narrow | `short | `long]=?,
+    ~year: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+    ~month: [@bs.string] [
+              | `numeric
+              | [@bs.as "2-digit"] `twoDigit
+              | `narrow
+              | `short
+              | `long
+            ]
+              =?,
+    ~day: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+    ~hour: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+    ~minute: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+    ~second: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+    ~timeZoneName: [@bs.string] [ | `short | `long]=?,
+    ~format: string=?,
+    unit
+  ) =>
+  dateTimeFormatOptions =
+  "";
+
+type relativeFormatOptions;
+
+[@bs.obj]
+external relativeFormatOptions:
+  (
+    ~style: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `numeric]=?,
+    ~units: [@bs.string] [ | `second | `minute | `hour | `day | `month | `year]
+              =?,
+    ~format: string=?,
+    ~now: int=?,
+    unit
+  ) =>
+  relativeFormatOptions =
+  "";
+
+type numberFormatOptions;
+
+[@bs.obj]
+external numberFormatOptions:
+  (
+    ~localeMatcher: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `lookup]=?,
+    ~style: [@bs.string] [ | `decimal | `currency | `percent]=?,
+    ~currency: string=?,
+    ~currencyDisplay: [@bs.string] [ | `symbol | `code | `name]=?,
+    ~useGrouping: bool=?,
+    ~minimumIntegerDigits: int=?,
+    ~minimumFractionDigits: int=?,
+    ~maximumFractionDigits: int=?,
+    ~minimumSignificantDigits: int=?,
+    ~maximumSignificantDigits: int=?,
+    unit
+  ) =>
+  numberFormatOptions =
+  "";
+
+type pluralFormatOptions;
+
+[@bs.obj]
+external pluralFormatOptions:
+  (~style: [@bs.string] [ | `cardinal | `ordinal]=?, unit) =>
+  pluralFormatOptions =
+  "";
+
 type message = {
   .
   "id": string,
   "defaultMessage": string,
 };
 
-type jsonMessage = {
-  .
-  "id": string,
-  "defaultMessage": string,
-  "message": Js.nullable(string),
+module Intl = {
+  type t;
+
+  [@bs.get] external locale: t => string = "";
+  [@bs.get] external formats: t => Js.t({..}) = "";
+  [@bs.get] external messages: t => Js.Dict.t(string) = "";
+  [@bs.get] external defaultLocale: t => string = "";
+  [@bs.get] external defaultFormats: t => Js.t({..}) = "";
+  [@bs.send] external formatDate: (t, Js.Date.t) => string = "";
+  [@bs.send]
+  external formatDateWithOptions:
+    (t, Js.Date.t, dateTimeFormatOptions) => string =
+    "formatDate";
+  [@bs.send] external formatTime: (t, Js.Date.t) => string = "";
+  [@bs.send]
+  external formatTimeWithOptions:
+    (t, Js.Date.t, dateTimeFormatOptions) => string =
+    "formatTime";
+  [@bs.send] external formatRelative: (t, Js.Date.t) => string = "";
+  [@bs.send]
+  external formatRelativeWithOptions:
+    (t, Js.Date.t, relativeFormatOptions) => string =
+    "formatRelative";
+  [@bs.send] external formatNumber: (t, float) => string = "";
+  [@bs.send]
+  external formatNumberWithOptions: (t, float, numberFormatOptions) => string =
+    "formatNumber";
+  [@bs.send] external formatPlural: (t, int) => string = "";
+  [@bs.send]
+  external formatPluralWithOptions: (t, int, pluralFormatOptions) => string =
+    "formatPlural";
+  [@bs.send] external formatMessage: (t, message) => string = "";
+  [@bs.send]
+  external formatMessageWithValues: (t, message, Js.t({..})) => string =
+    "formatMessage";
+  [@bs.send] external formatHtmlMessage: (t, message) => string = "";
+  [@bs.send]
+  external formatHtmlMessageWithValues: (t, message, Js.t({..})) => string =
+    "formatHtmlMessage";
+  [@bs.send] external now: (t, unit) => int = "";
 };
 
-type jsonMessages = array(jsonMessage);
+type intl = Intl.t;
 
-/* addLocaleData */
-type localeData('t) = {.. "locale": string} as 't;
+[@bs.module "react-intl"] external useIntl: unit => intl = "";
 
-[@bs.module "react-intl"] external addLocaleData: localeData('t) => unit = "";
+type textComponent;
 
-/* defineMessages */
-type defineMessages('m) = (. 'm) => 'm;
-
-[@bs.module "react-intl"]
-external defineMessages: defineMessages(Js.t({..})) = "";
-
-/* Formatters */
-type localeMatcher =
-  | BestFitLocaleMatcher
-  | LookupLocaleMatcher;
-
-let mapReasonLocaleMatcherToJs = localeMatcher =>
-  Js.Option.map(
-    (. localeMatcher) =>
-      switch (localeMatcher) {
-      | BestFitLocaleMatcher => "best fit"
-      | LookupLocaleMatcher => "lookup"
-      },
-    localeMatcher,
-  );
-
-type formatMatcher =
-  | BestFitFormatMatcher
-  | BasicFormatMatcher;
-
-let mapReasonFormatMatcherToJs = formatMatcher =>
-  Js.Option.map(
-    (. formatMatcher) =>
-      switch (formatMatcher) {
-      | BestFitFormatMatcher => "best fit"
-      | BasicFormatMatcher => "basic"
-      },
-    formatMatcher,
-  );
-
-type numeralFormat =
-  | NumericNumeralFormat
-  | TwoDigitNumeralFormat;
-
-let mapReasonNumeralFormatToJs = numeralFormat =>
-  Js.Option.map(
-    (. numeralFormat) =>
-      switch (numeralFormat) {
-      | NumericNumeralFormat => "numeric"
-      | TwoDigitNumeralFormat => "2-digit"
-      },
-    numeralFormat,
-  );
-
-type textualFormat =
-  | NarrowTextualFormat
-  | ShortTextualFormat
-  | LongTextualFormat;
-
-let mapReasonTextualFormatToJs = textualFormat =>
-  Js.Option.map(
-    (. textualFormat) =>
-      switch (textualFormat) {
-      | NarrowTextualFormat => "narrow"
-      | ShortTextualFormat => "short"
-      | LongTextualFormat => "long"
-      },
-    textualFormat,
-  );
-
-type mixedFormat =
-  | NumericMixedFormat
-  | TwoDigitMixedFormat
-  | NarrowMixedFormat
-  | ShortMixedFormat
-  | LongMixedFormat;
-
-let mapReasonMixedFormatToJs = mixedFormat =>
-  Js.Option.map(
-    (. mixedFormat) =>
-      switch (mixedFormat) {
-      | NarrowMixedFormat => "narrow"
-      | ShortMixedFormat => "short"
-      | LongMixedFormat => "long"
-      | NumericMixedFormat => "numeric"
-      | TwoDigitMixedFormat => "2-digit"
-      },
-    mixedFormat,
-  );
-
-type timeZoneName =
-  | ShortTimeZoneName
-  | LongTimeZoneName;
-
-let mapReasonTimeZoneNameToJs = timeZoneName =>
-  Js.Option.map(
-    (. timeZoneName) =>
-      switch (timeZoneName) {
-      | ShortTimeZoneName => "short"
-      | LongTimeZoneName => "long"
-      },
-    timeZoneName,
-  );
-
-type dateTimeFormatOptionsRe = {
-  .
-  "localeMatcher": option(localeMatcher),
-  "formatMatcher": option(formatMatcher),
-  "timeZone": option(string),
-  "hour12": option(bool),
-  "weekday": option(textualFormat),
-  "era": option(textualFormat),
-  "year": option(numeralFormat),
-  "month": option(mixedFormat),
-  "day": option(numeralFormat),
-  "hour": option(numeralFormat),
-  "minute": option(numeralFormat),
-  "second": option(numeralFormat),
-  "timeZoneName": option(timeZoneName),
-  "format": option(string),
-};
-
-type dateTimeFormatOptionsJs = {
-  .
-  "localeMatcher": option(string),
-  "formatMatcher": option(string),
-  "timeZone": option(string),
-  "hour12": option(bool),
-  "weekday": option(string),
-  "era": option(string),
-  "year": option(string),
-  "month": option(string),
-  "day": option(string),
-  "hour": option(string),
-  "minute": option(string),
-  "second": option(string),
-  "timeZoneName": option(string),
-  "format": option(string),
-};
-
-let mapReasonDateTimeFormatOptionsToJs =
-    (options: dateTimeFormatOptionsRe): dateTimeFormatOptionsJs => {
-  "localeMatcher": options##localeMatcher->mapReasonLocaleMatcherToJs,
-  "formatMatcher": options##formatMatcher->mapReasonFormatMatcherToJs,
-  "timeZone": options##timeZone,
-  "hour12": options##hour12,
-  "weekday": options##weekday->mapReasonTextualFormatToJs,
-  "era": options##era->mapReasonTextualFormatToJs,
-  "year": options##year->mapReasonNumeralFormatToJs,
-  "month": options##month->mapReasonMixedFormatToJs,
-  "day": options##day->mapReasonNumeralFormatToJs,
-  "hour": options##hour->mapReasonNumeralFormatToJs,
-  "minute": options##minute->mapReasonNumeralFormatToJs,
-  "second": options##second->mapReasonNumeralFormatToJs,
-  "timeZoneName": options##timeZoneName->mapReasonTimeZoneNameToJs,
-  "format": options##format,
-};
-
-type relativeStyle =
-  | BestFitRelativeStyle
-  | NumericRelativeStyle;
-
-let mapReasonRelativeStyleToJs = relativeStyle =>
-  Js.Option.map(
-    (. relativeStyle) =>
-      switch (relativeStyle) {
-      | BestFitRelativeStyle => "best fit"
-      | NumericRelativeStyle => "numeric"
-      },
-    relativeStyle,
-  );
-
-type units =
-  | Second
-  | Minute
-  | Hour
-  | Day
-  | Month
-  | Year;
-
-let mapReasonUnitsToJs = units =>
-  Js.Option.map(
-    (. units) =>
-      switch (units) {
-      | Second => "second"
-      | Minute => "minute"
-      | Hour => "hour"
-      | Day => "day"
-      | Month => "month"
-      | Year => "year"
-      },
-    units,
-  );
-
-type relativeFormatOptionsRe = {
-  .
-  "style": option(relativeStyle),
-  "units": option(units),
-  "format": option(string),
-  "now": option(int),
-};
-
-type relativeFormatOptionsJs = {
-  .
-  "style": option(string),
-  "units": option(string),
-  "format": option(string),
-  "now": option(int),
-};
-
-let mapReasonRelativeFormatOptionsToJs =
-    (options: relativeFormatOptionsRe): relativeFormatOptionsJs => {
-  "style": options##style->mapReasonRelativeStyleToJs,
-  "units": options##units->mapReasonUnitsToJs,
-  "format": options##format,
-  "now": options##now,
-};
-
-type numberStyle =
-  | DecimalNumberStyle
-  | CurrencyNumberStyle
-  | PercentNumberStyle;
-
-let mapReasonNumberStyleToJs = numberStyle =>
-  Js.Option.map(
-    (. numberStyle) =>
-      switch (numberStyle) {
-      | DecimalNumberStyle => "decimal"
-      | CurrencyNumberStyle => "currency"
-      | PercentNumberStyle => "percent"
-      },
-    numberStyle,
-  );
-
-type currencyDisplay =
-  | SymbolCurrencyDisplay
-  | CodeCurrencyDisplay
-  | NameCurrencyDisplay;
-
-let mapReasonCurrencyDisplayToJs = currencyDisplay =>
-  Js.Option.map(
-    (. currencyDisplay) =>
-      switch (currencyDisplay) {
-      | SymbolCurrencyDisplay => "symbol"
-      | CodeCurrencyDisplay => "code"
-      | NameCurrencyDisplay => "name"
-      },
-    currencyDisplay,
-  );
-
-type numberFormatOptionsRe = {
-  .
-  "localeMatcher": option(localeMatcher),
-  "style": option(numberStyle),
-  "currency": option(string),
-  "currencyDisplay": option(currencyDisplay),
-  "useGrouping": option(bool),
-  "minimumIntegerDigits": option(int),
-  "minimumFractionDigits": option(int),
-  "maximumFractionDigits": option(int),
-  "minimumSignificantDigits": option(int),
-  "maximumSignificantDigits": option(int),
-};
-
-type numberFormatOptionsJs = {
-  .
-  "localeMatcher": option(string),
-  "style": option(string),
-  "currency": option(string),
-  "currencyDisplay": option(string),
-  "useGrouping": option(bool),
-  "minimumIntegerDigits": option(int),
-  "minimumFractionDigits": option(int),
-  "maximumFractionDigits": option(int),
-  "minimumSignificantDigits": option(int),
-  "maximumSignificantDigits": option(int),
-};
-
-let mapReasonNumberFormatOptionsToJs =
-    (options: numberFormatOptionsRe): numberFormatOptionsJs => {
-  "localeMatcher": options##localeMatcher->mapReasonLocaleMatcherToJs,
-  "style": options##style->mapReasonNumberStyleToJs,
-  "currency": options##currency,
-  "currencyDisplay": options##currencyDisplay->mapReasonCurrencyDisplayToJs,
-  "useGrouping": options##useGrouping,
-  "minimumIntegerDigits": options##minimumIntegerDigits,
-  "minimumFractionDigits": options##minimumFractionDigits,
-  "maximumFractionDigits": options##maximumFractionDigits,
-  "minimumSignificantDigits": options##minimumSignificantDigits,
-  "maximumSignificantDigits": options##maximumSignificantDigits,
-};
-
-type pluralStyle =
-  | CardinalPluralStyle
-  | OrdinalPluralStyle;
-
-let mapReasonPluralStyleToJs = pluralStyle =>
-  Js.Option.map(
-    (. pluralStyle) =>
-      switch (pluralStyle) {
-      | CardinalPluralStyle => "cardinal"
-      | OrdinalPluralStyle => "ordinal"
-      },
-    pluralStyle,
-  );
-
-type pluralFormatOptionsRe = {. "style": option(pluralStyle)};
-
-type pluralFormatOptionsJs = {. "style": option(string)};
-
-let mapReasonPluralFormatOptionsToJs = options => {
-  "style": options##style->mapReasonPluralStyleToJs,
-};
-
-/* Components */
-type domTag =
-  | Span
-  | Div
-  | H1
-  | H2
-  | H3
-  | H4
-  | H5
-  | H6
-  | P
-  | Strong
-  | B
-  | I
-  | Em
-  | Mark
-  | Small
-  | Del
-  | Ins
-  | Sub
-  | Sup;
-
-type textComponent('props) =
-  | DomTag(domTag)
-  | ReactComponent(React.component('props));
-
-let mapDomTagToString = tag =>
-  switch (tag) {
-  | Span => "span"
-  | Div => "div"
-  | P => "p"
-  | H1 => "h1"
-  | H2 => "h2"
-  | H3 => "h3"
-  | H4 => "h4"
-  | H5 => "h5"
-  | H6 => "h6"
-  | Strong => "strong"
-  | B => "b"
-  | I => "i"
-  | Em => "em"
-  | Mark => "mark"
-  | Small => "small"
-  | Del => "del"
-  | Ins => "ins"
-  | Sub => "sub"
-  | Sup => "sup"
-  };
-
-let mapOptDomTagToString = tag =>
-  switch (tag) {
-  | Some(tag) => Some(tag->mapDomTagToString)
-  | None => None
-  };
-
-let mapTextComponentToJs = textComponent =>
-  switch (textComponent) {
-  | DomTag(domTag) => domTag->mapDomTagToString->Obj.magic
-  | ReactComponent(reactComponent) => reactComponent->Obj.magic
-  };
-
-let mapOptTextComponentToJs = textComponent =>
-  textComponent->Belt.Option.map(mapTextComponentToJs);
-
-type errorHandler = string => unit;
+external domTag: string => textComponent = "%identity";
+external textComponent: React.component('props) => textComponent =
+  "%identity";
 
 module IntlProvider = {
-  type props('a, 'b) = {
-    .
-    "locale": option(string),
-    "formats": option(Js.t({..} as 'a)), /* TODO */
-    "messages": option(Js.Dict.t(string)),
-    "defaultLocale": option(string),
-    "defaultFormats": option(Js.t({..} as 'a)), /* TODO */
-    "textComponent": option(textComponent('b)),
-    "initialNow": option(int),
-    "onError": option(errorHandler),
-  };
-
-  [@bs.obj]
-  external makeProps:
+  [@react.component] [@bs.module "react-intl"]
+  external make:
     (
       ~locale: string=?,
-      ~formats: Js.t({..} as 'a)=?, /* TODO */
+      ~formats: Js.t({..})=?, /* TODO */
       ~messages: Js.Dict.t(string)=?,
       ~defaultLocale: string=?,
-      ~defaultFormats: Js.t({..} as 'a)=?, /* TODO */
-      ~textComponent: option(textComponent('b))=?,
+      ~defaultFormats: Js.t({..})=?, /* TODO */
+      ~textComponent: textComponent=?,
       ~initialNow: int=?,
-      ~onError: errorHandler=?,
-      ~children: React.element,
-      ~key: string=?,
-      unit
+      ~onError: string => unit=?,
+      ~children: React.element
     ) =>
-    props('a, 'b) =
-    "";
-
-  let makeProps =
-      (
-        ~locale=?,
-        ~formats=?,
-        ~messages=?,
-        ~defaultLocale=?,
-        ~defaultFormats=?,
-        ~textComponent=?,
-        ~initialNow=?,
-        ~onError=?,
-        ~children,
-        ~key=?,
-        (),
-      ) =>
-    makeProps(
-      ~locale?,
-      ~formats?,
-      ~messages?,
-      ~defaultLocale?,
-      ~defaultFormats?,
-      ~textComponent=?textComponent->mapOptTextComponentToJs,
-      ~initialNow?,
-      ~onError?,
-      ~children,
-      ~key?,
-      (),
-    );
-
-  [@bs.module "react-intl"]
-  external make: React.component(props('a, 'b)) = "IntlProvider";
+    React.element =
+    "IntlProvider";
 };
-
-type intlJs('t) =
-  {
-    .
-    "locale": string,
-    "formats": Js.t({..}), /* TODO */
-    "messages": Js.Dict.t(string),
-    "defaultLocale": string,
-    "defaultFormats": Js.t({..}), /* TODO */
-    "formatDate":
-      [@bs.meth] (
-        (Js.Date.t, Js.undefined(dateTimeFormatOptionsJs)) => string
-      ),
-    "formatTime":
-      [@bs.meth] (
-        (Js.Date.t, Js.undefined(dateTimeFormatOptionsJs)) => string
-      ),
-    "formatRelative":
-      [@bs.meth] (
-        (Js.Date.t, Js.undefined(relativeFormatOptionsJs)) => string
-      ),
-    "formatNumber":
-      [@bs.meth] ((float, Js.undefined(numberFormatOptionsJs)) => string),
-    "formatPlural":
-      [@bs.meth] ((int, Js.undefined(pluralFormatOptionsJs)) => string),
-    "formatMessage":
-      [@bs.meth] ((message, Js.undefined(Js.t({..}))) => string),
-    "formatHTMLMessage":
-      [@bs.meth] ((message, Js.undefined(Js.t({..}))) => string),
-    "now": [@bs.meth] (unit => int),
-  } as 't;
-
-type intl('t) = {
-  locale: string,
-  formats: Js.t({..} as 't), /* TODO */
-  messages: Js.Dict.t(string),
-  defaultLocale: string,
-  defaultFormats: Js.t({..} as 't), /* TODO */
-  formatDate: Js.Date.t => string,
-  formatDateWithOptions: (dateTimeFormatOptionsRe, Js.Date.t) => string,
-  formatTime: Js.Date.t => string,
-  formatTimeWithOptions: (dateTimeFormatOptionsRe, Js.Date.t) => string,
-  formatRelative: Js.Date.t => string,
-  formatRelativeWithOptions: (relativeFormatOptionsRe, Js.Date.t) => string,
-  formatInt: int => string,
-  formatIntWithOptions: (numberFormatOptionsRe, int) => string,
-  formatFloat: float => string,
-  formatFloatWithOptions: (numberFormatOptionsRe, float) => string,
-  formatPlural: int => string,
-  formatPluralWithOptions: (pluralFormatOptionsRe, int) => string,
-  formatMessage: message => string,
-  formatMessageWithValues: (Js.t({..} as 't), message) => string,
-  formatHTMLMessage: message => string,
-  formatHTMLMessageWithValues: (Js.t({..} as 't), message) => string,
-  now: unit => int,
-};
-
-let mapIntlJsToReason = (intlJs: intlJs('t)): intl('a) => {
-  locale: intlJs##locale,
-  formats: intlJs##formats,
-  messages: intlJs##messages,
-  defaultLocale: intlJs##defaultLocale,
-  defaultFormats: intlJs##defaultFormats,
-  formatDate: value => intlJs##formatDate(value, Js.undefined),
-  formatDateWithOptions: (options, value) =>
-    intlJs##formatDate(
-      value,
-      Some(options->mapReasonDateTimeFormatOptionsToJs)
-      ->Js.Undefined.fromOption,
-    ),
-  formatTime: value => intlJs##formatTime(value, Js.undefined),
-  formatTimeWithOptions: (options, value) =>
-    intlJs##formatTime(
-      value,
-      Some(options->mapReasonDateTimeFormatOptionsToJs)
-      ->Js.Undefined.fromOption,
-    ),
-  formatRelative: value => intlJs##formatRelative(value, Js.undefined),
-  formatRelativeWithOptions: (options, value) =>
-    intlJs##formatRelative(
-      value,
-      Some(options->mapReasonRelativeFormatOptionsToJs)
-      ->Js.Undefined.fromOption,
-    ),
-  formatInt: value => intlJs##formatNumber(value->float_of_int, Js.undefined),
-  formatIntWithOptions: (options, value) =>
-    intlJs##formatNumber(
-      value->float_of_int,
-      Some(options->mapReasonNumberFormatOptionsToJs)
-      ->Js.Undefined.fromOption,
-    ),
-  formatFloat: value => intlJs##formatNumber(value, Js.undefined),
-  formatFloatWithOptions: (options, value) =>
-    intlJs##formatNumber(
-      value,
-      Some(options->mapReasonNumberFormatOptionsToJs)
-      ->Js.Undefined.fromOption,
-    ),
-  formatPlural: value => intlJs##formatPlural(value, Js.undefined),
-  formatPluralWithOptions: (options, value) =>
-    intlJs##formatPlural(
-      value,
-      Some(options->mapReasonPluralFormatOptionsToJs)
-      ->Js.Undefined.fromOption,
-    ),
-  formatMessage: message => intlJs##formatMessage(message, Js.undefined),
-  formatMessageWithValues: (values, message) =>
-    intlJs##formatMessage(message, Some(values)->Js.Undefined.fromOption),
-  formatHTMLMessage: message =>
-    intlJs##formatHTMLMessage(message, Js.undefined),
-  formatHTMLMessageWithValues: (values, message) =>
-    intlJs##formatHTMLMessage(
-      message,
-      Some(values)->Js.Undefined.fromOption,
-    ),
-  now: () => intlJs##now(),
-};
-
-[@bs.module "react-intl"] external useIntl: unit => intlJs('t) = "useIntl";
-let useIntl = () => useIntl()->mapIntlJsToReason;
 
 module FormattedMessage = {
-  [@bs.module "react-intl"] [@react.component]
+  [@react.component] [@bs.module "react-intl"]
   external make:
     (
       ~id: string,
       ~defaultMessage: string,
-      ~values: Js.t({..}) as 'a=?,
-      ~tagName: [@bs.string] [
-                  | `span
-                  | `div
-                  | `p
-                  | `h1
-                  | `h2
-                  | `h3
-                  | `h4
-                  | `h5
-                  | `h6
-                  | `strong
-                  | `b
-                  | `i
-                  | `em
-                  | `mark
-                  | `small
-                  | `del
-                  | `ins
-                  | `sub
-                  | `sup
-                ]
-                  =?
+      ~values: Js.t({..})=?,
+      ~tagName: string=?,
+      ~children: (~formattedMessage: React.element) => React.element=?
     ) =>
     React.element =
     "FormattedMessage";
 };
 
-// DefinedMessage is another wrapper for FormattedMessage.
-// It takes the id and defaultMessage props from a passed message object.
-module DefinedMessage = {
-  let make = FormattedMessage.make;
-  let makeProps = (~message: message, ~values=?, ~tagName=?, ~key=?, ()) =>
-    FormattedMessage.makeProps(
-      ~id=message##id,
-      ~defaultMessage=message##defaultMessage,
-      ~values?,
-      ~tagName?,
-      ~key?,
-      (),
-    );
+module FormattedHTMLMessage = {
+  [@react.component] [@bs.module "react-intl"]
+  external make:
+    (
+      ~id: string,
+      ~defaultMessage: string,
+      ~values: Js.t({..})=?,
+      ~tagName: string=?,
+      ~children: (~formattedMessage: React.element) => React.element=?
+    ) =>
+    React.element =
+    "FormattedHTMLMessage";
 };
 
 module FormattedDate = {
-  type props = {
-    .
-    "value": Js.Date.t,
-    "format": option(string),
-    "localeMatcher": option(string),
-    "formatMatcher": option(string),
-    "timeZone": option(string),
-    "hour12": option(bool),
-    "weekday": option(string),
-    "era": option(string),
-    "year": option(string),
-    "month": option(string),
-    "day": option(string),
-    "hour": option(string),
-    "minute": option(string),
-    "second": option(string),
-    "timeZoneName": option(string),
-  };
-
-  [@bs.obj]
-  external makeProps:
+  [@react.component] [@bs.module "react-intl"]
+  external make:
     (
       ~value: Js.Date.t,
-      ~format: string=?,
-      ~localeMatcher: string=?,
-      ~formatMatcher: string=?,
+      ~localeMatcher: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `lookup]
+                        =?,
+      ~formatMatcher: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `basic]=?,
       ~timeZone: string=?,
       ~hour12: bool=?,
-      ~weekday: string=?,
-      ~era: string=?,
-      ~year: string=?,
-      ~month: string=?,
-      ~day: string=?,
-      ~hour: string=?,
-      ~minute: string=?,
-      ~second: string=?,
-      ~timeZoneName: string=?,
-      ~key: string=?,
-      unit
+      ~weekday: [@bs.string] [ | `narrow | `short | `long]=?,
+      ~era: [@bs.string] [ | `narrow | `short | `long]=?,
+      ~year: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~month: [@bs.string] [
+                | `numeric
+                | [@bs.as "2-digit"] `twoDigit
+                | `narrow
+                | `short
+                | `long
+              ]
+                =?,
+      ~day: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~hour: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~minute: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~second: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~timeZoneName: [@bs.string] [ | `short | `long]=?,
+      ~format: string=?,
+      ~children: (~formattedDate: string) => React.element=?
     ) =>
-    props =
-    "";
-
-  let makeProps =
-      (
-        ~value: Js.Date.t,
-        ~format: option(string)=?,
-        ~localeMatcher: option(localeMatcher)=?,
-        ~formatMatcher: option(formatMatcher)=?,
-        ~timeZone: option(string)=?,
-        ~hour12: option(bool)=?,
-        ~weekday: option(textualFormat)=?,
-        ~era: option(textualFormat)=?,
-        ~year: option(numeralFormat)=?,
-        ~month: option(mixedFormat)=?,
-        ~day: option(numeralFormat)=?,
-        ~hour: option(numeralFormat)=?,
-        ~minute: option(numeralFormat)=?,
-        ~second: option(numeralFormat)=?,
-        ~timeZoneName: option(timeZoneName)=?,
-        ~key=?,
-        (),
-      ) =>
-    makeProps(
-      ~value,
-      ~format?,
-      ~localeMatcher=?localeMatcher->mapReasonLocaleMatcherToJs,
-      ~formatMatcher=?formatMatcher->mapReasonFormatMatcherToJs,
-      ~timeZone?,
-      ~hour12?,
-      ~weekday=?weekday->mapReasonTextualFormatToJs,
-      ~era=?era->mapReasonTextualFormatToJs,
-      ~year=?year->mapReasonNumeralFormatToJs,
-      ~month=?month->mapReasonMixedFormatToJs,
-      ~day=?day->mapReasonNumeralFormatToJs,
-      ~hour=?hour->mapReasonNumeralFormatToJs,
-      ~minute=?minute->mapReasonNumeralFormatToJs,
-      ~second=?second->mapReasonNumeralFormatToJs,
-      ~timeZoneName=?timeZoneName->mapReasonTimeZoneNameToJs,
-      ~key?,
-      (),
-    );
-
-  [@bs.module "react-intl"]
-  external make: React.component(props) = "FormattedDate";
+    React.element =
+    "FormattedDate";
 };
 
 module FormattedTime = {
-  type props = {
-    .
-    "value": Js.Date.t,
-    "format": option(string),
-    "localeMatcher": option(string),
-    "formatMatcher": option(string),
-    "timeZone": option(string),
-    "hour12": option(bool),
-    "weekday": option(string),
-    "era": option(string),
-    "year": option(string),
-    "month": option(string),
-    "day": option(string),
-    "hour": option(string),
-    "minute": option(string),
-    "second": option(string),
-    "timeZoneName": option(string),
-  };
-
-  [@bs.obj]
-  external makeProps:
+  [@react.component] [@bs.module "react-intl"]
+  external make:
     (
       ~value: Js.Date.t,
-      ~format: string=?,
-      ~localeMatcher: string=?,
-      ~formatMatcher: string=?,
+      ~localeMatcher: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `lookup]
+                        =?,
+      ~formatMatcher: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `basic]=?,
       ~timeZone: string=?,
       ~hour12: bool=?,
-      ~weekday: string=?,
-      ~era: string=?,
-      ~year: string=?,
-      ~month: string=?,
-      ~day: string=?,
-      ~hour: string=?,
-      ~minute: string=?,
-      ~second: string=?,
-      ~timeZoneName: string=?,
-      ~key: string=?,
-      unit
+      ~weekday: [@bs.string] [ | `narrow | `short | `long]=?,
+      ~era: [@bs.string] [ | `narrow | `short | `long]=?,
+      ~year: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~month: [@bs.string] [
+                | `numeric
+                | [@bs.as "2-digit"] `twoDigit
+                | `narrow
+                | `short
+                | `long
+              ]
+                =?,
+      ~day: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~hour: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~minute: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~second: [@bs.string] [ | `numeric | [@bs.as "2-digit"] `twoDigit]=?,
+      ~timeZoneName: [@bs.string] [ | `short | `long]=?,
+      ~format: string=?,
+      ~children: (~formattedDate: string) => React.element=?
     ) =>
-    props =
-    "";
-
-  let makeProps =
-      (
-        ~value: Js.Date.t,
-        ~format: option(string)=?,
-        ~localeMatcher: option(localeMatcher)=?,
-        ~formatMatcher: option(formatMatcher)=?,
-        ~timeZone: option(string)=?,
-        ~hour12: option(bool)=?,
-        ~weekday: option(textualFormat)=?,
-        ~era: option(textualFormat)=?,
-        ~year: option(numeralFormat)=?,
-        ~month: option(mixedFormat)=?,
-        ~day: option(numeralFormat)=?,
-        ~hour: option(numeralFormat)=?,
-        ~minute: option(numeralFormat)=?,
-        ~second: option(numeralFormat)=?,
-        ~timeZoneName: option(timeZoneName)=?,
-        ~key=?,
-        (),
-      ) =>
-    makeProps(
-      ~value,
-      ~format?,
-      ~localeMatcher=?localeMatcher->mapReasonLocaleMatcherToJs,
-      ~formatMatcher=?formatMatcher->mapReasonFormatMatcherToJs,
-      ~timeZone?,
-      ~hour12?,
-      ~weekday=?weekday->mapReasonTextualFormatToJs,
-      ~era=?era->mapReasonTextualFormatToJs,
-      ~year=?year->mapReasonNumeralFormatToJs,
-      ~month=?month->mapReasonMixedFormatToJs,
-      ~day=?day->mapReasonNumeralFormatToJs,
-      ~hour=?hour->mapReasonNumeralFormatToJs,
-      ~minute=?minute->mapReasonNumeralFormatToJs,
-      ~second=?second->mapReasonNumeralFormatToJs,
-      ~timeZoneName=?timeZoneName->mapReasonTimeZoneNameToJs,
-      ~key?,
-      (),
-    );
-
-  [@bs.module "react-intl"]
-  external make: React.component(props) = "FormattedDate";
+    React.element =
+    "FormattedTime";
 };
 
-/* Utils */
-let wrapUnicodeString = (input: string) => {j|$input|j};
+module FormattedRelative = {
+  [@react.component] [@bs.module "react-intl"]
+  external make:
+    (
+      ~value: Js.Date.t,
+      ~style: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `numeric]=?,
+      ~units: [@bs.string] [
+                | `second
+                | `minute
+                | `hour
+                | `day
+                | `month
+                | `year
+              ]
+                =?,
+      ~format: string=?,
+      ~updateInterval: float=?,
+      ~initialNow: int=?,
+      ~children: (~formattedDate: string) => React.element=?
+    ) =>
+    React.element =
+    "FormattedRelative";
+};
 
-let wrapOptUnicodeString = (input: Js.nullable(string)) =>
-  switch (input->Js.Nullable.toOption) {
-  | Some(input) => input->wrapUnicodeString
-  | None => ""
-  };
+module FormattedNumber = {
+  [@react.component] [@bs.module "react-intl"]
+  external make:
+    (
+      ~value: float,
+      ~localeMatcher: [@bs.string] [ | [@bs.as "best fit"] `bestFit | `lookup]
+                        =?,
+      ~style: [@bs.string] [ | `decimal | `currency | `percent]=?,
+      ~currency: string=?,
+      ~currencyDisplay: [@bs.string] [ | `symbol | `code | `name]=?,
+      ~useGrouping: bool=?,
+      ~minimumIntegerDigits: int=?,
+      ~minimumFractionDigits: int=?,
+      ~maximumFractionDigits: int=?,
+      ~minimumSignificantDigits: int=?,
+      ~maximumSignificantDigits: int=?,
+      ~format: string=?,
+      ~children: (~formattedNumber: string) => React.element=?
+    ) =>
+    React.element =
+    "FormattedNumber";
+};
 
-let messagesArrayToDict = (translation: jsonMessages) =>
-  translation->Belt.Array.reduce(
-    Js.Dict.empty(),
-    (dict, message) => {
-      let unicodeMessage = message##message->wrapOptUnicodeString;
-      let unicodeDefaultMessage = message##defaultMessage->wrapUnicodeString;
-      Js.Dict.set(
-        dict,
-        message##id,
-        unicodeMessage !== "" ? unicodeMessage : unicodeDefaultMessage,
-      );
-      dict;
-    },
-  );
+module FormattedPlural = {
+  [@react.component] [@bs.module "react-intl"]
+  external make:
+    (
+      ~value: int,
+      ~style: [@bs.string] [ | `cardinal | `ordinal]=?,
+      ~other: React.element,
+      ~zero: React.element=?,
+      ~one: React.element=?,
+      ~two: React.element=?,
+      ~few: React.element=?,
+      ~many: React.element=?,
+      ~children: (~formattedPlural: string) => React.element=?
+    ) =>
+    React.element =
+    "FormattedPlural";
+};

--- a/src/ReactIntlCompat.re
+++ b/src/ReactIntlCompat.re
@@ -1,0 +1,748 @@
+/* Common */
+type message = {
+  .
+  "id": string,
+  "defaultMessage": string,
+};
+
+type jsonMessage = {
+  .
+  "id": string,
+  "defaultMessage": string,
+  "message": Js.nullable(string),
+};
+
+type jsonMessages = array(jsonMessage);
+
+/* addLocaleData */
+type localeData('t) = {.. "locale": string} as 't;
+
+[@bs.module "react-intl"] external addLocaleData: localeData('t) => unit = "";
+
+/* defineMessages */
+type defineMessages('m) = (. 'm) => 'm;
+
+[@bs.module "react-intl"]
+external defineMessages: defineMessages(Js.t({..})) = "";
+
+/* Formatters */
+type localeMatcher =
+  | BestFitLocaleMatcher
+  | LookupLocaleMatcher;
+
+let mapReasonLocaleMatcherToJs = localeMatcher =>
+  Js.Option.map(
+    (. localeMatcher) =>
+      switch (localeMatcher) {
+      | BestFitLocaleMatcher => "best fit"
+      | LookupLocaleMatcher => "lookup"
+      },
+    localeMatcher,
+  )
+  |> Js.Nullable.fromOption;
+
+type formatMatcher =
+  | BestFitFormatMatcher
+  | BasicFormatMatcher;
+
+let mapReasonFormatMatcherToJs = formatMatcher =>
+  Js.Option.map(
+    (. formatMatcher) =>
+      switch (formatMatcher) {
+      | BestFitFormatMatcher => "best fit"
+      | BasicFormatMatcher => "basic"
+      },
+    formatMatcher,
+  )
+  |> Js.Nullable.fromOption;
+
+type numeralFormat =
+  | NumericNumeralFormat
+  | TwoDigitNumeralFormat;
+
+let mapReasonNumeralFormatToJs = numeralFormat =>
+  Js.Option.map(
+    (. numeralFormat) =>
+      switch (numeralFormat) {
+      | NumericNumeralFormat => "numeric"
+      | TwoDigitNumeralFormat => "2-digit"
+      },
+    numeralFormat,
+  )
+  |> Js.Nullable.fromOption;
+
+type textualFormat =
+  | NarrowTextualFormat
+  | ShortTextualFormat
+  | LongTextualFormat;
+
+let mapReasonTextualFormatToJs = textualFormat =>
+  Js.Option.map(
+    (. textualFormat) =>
+      switch (textualFormat) {
+      | NarrowTextualFormat => "narrow"
+      | ShortTextualFormat => "short"
+      | LongTextualFormat => "long"
+      },
+    textualFormat,
+  )
+  |> Js.Nullable.fromOption;
+
+type mixedFormat =
+  | NumericMixedFormat
+  | TwoDigitMixedFormat
+  | NarrowMixedFormat
+  | ShortMixedFormat
+  | LongMixedFormat;
+
+let mapReasonMixedFormatToJs = mixedFormat =>
+  Js.Option.map(
+    (. mixedFormat) =>
+      switch (mixedFormat) {
+      | NarrowMixedFormat => "narrow"
+      | ShortMixedFormat => "short"
+      | LongMixedFormat => "long"
+      | NumericMixedFormat => "numeric"
+      | TwoDigitMixedFormat => "2-digit"
+      },
+    mixedFormat,
+  )
+  |> Js.Nullable.fromOption;
+
+type timeZoneName =
+  | ShortTimeZoneName
+  | LongTimeZoneName;
+
+let mapReasonTimeZoneNameToJs = timeZoneName =>
+  Js.Option.map(
+    (. timeZoneName) =>
+      switch (timeZoneName) {
+      | ShortTimeZoneName => "short"
+      | LongTimeZoneName => "long"
+      },
+    timeZoneName,
+  )
+  |> Js.Nullable.fromOption;
+
+type dateTimeFormatOptionsRe = {
+  .
+  "localeMatcher": option(localeMatcher),
+  "formatMatcher": option(formatMatcher),
+  "timeZone": option(string),
+  "hour12": option(bool),
+  "weekday": option(textualFormat),
+  "era": option(textualFormat),
+  "year": option(numeralFormat),
+  "month": option(mixedFormat),
+  "day": option(numeralFormat),
+  "hour": option(numeralFormat),
+  "minute": option(numeralFormat),
+  "second": option(numeralFormat),
+  "timeZoneName": option(timeZoneName),
+  "format": option(string),
+};
+
+type dateTimeFormatOptionsJs = {
+  .
+  "localeMatcher": Js.nullable(string),
+  "formatMatcher": Js.nullable(string),
+  "timeZone": Js.nullable(string),
+  "hour12": Js.nullable(bool),
+  "weekday": Js.nullable(string),
+  "era": Js.nullable(string),
+  "year": Js.nullable(string),
+  "month": Js.nullable(string),
+  "day": Js.nullable(string),
+  "hour": Js.nullable(string),
+  "minute": Js.nullable(string),
+  "second": Js.nullable(string),
+  "timeZoneName": Js.nullable(string),
+  "format": Js.nullable(string),
+};
+
+let mapReasonDateTimeFormatOptionsToJs =
+    (options: dateTimeFormatOptionsRe): dateTimeFormatOptionsJs => {
+  "localeMatcher": options##localeMatcher |> mapReasonLocaleMatcherToJs,
+  "formatMatcher": options##formatMatcher |> mapReasonFormatMatcherToJs,
+  "timeZone": options##timeZone |> Js.Nullable.fromOption,
+  "hour12": options##hour12 |> Js.Nullable.fromOption,
+  "weekday": options##weekday |> mapReasonTextualFormatToJs,
+  "era": options##era |> mapReasonTextualFormatToJs,
+  "year": options##year |> mapReasonNumeralFormatToJs,
+  "month": options##month |> mapReasonMixedFormatToJs,
+  "day": options##day |> mapReasonNumeralFormatToJs,
+  "hour": options##hour |> mapReasonNumeralFormatToJs,
+  "minute": options##minute |> mapReasonNumeralFormatToJs,
+  "second": options##second |> mapReasonNumeralFormatToJs,
+  "timeZoneName": options##timeZoneName |> mapReasonTimeZoneNameToJs,
+  "format": options##format |> Js.Nullable.fromOption,
+};
+
+type relativeStyle =
+  | BestFitRelativeStyle
+  | NumericRelativeStyle;
+
+let mapReasonRelativeStyleToJs = relativeStyle =>
+  Js.Option.map(
+    (. relativeStyle) =>
+      switch (relativeStyle) {
+      | BestFitRelativeStyle => "best fit"
+      | NumericRelativeStyle => "numeric"
+      },
+    relativeStyle,
+  )
+  |> Js.Nullable.fromOption;
+
+type units =
+  | Second
+  | Minute
+  | Hour
+  | Day
+  | Month
+  | Year;
+
+let mapReasonUnitsToJs = units =>
+  Js.Option.map(
+    (. units) =>
+      switch (units) {
+      | Second => "second"
+      | Minute => "minute"
+      | Hour => "hour"
+      | Day => "day"
+      | Month => "month"
+      | Year => "year"
+      },
+    units,
+  )
+  |> Js.Nullable.fromOption;
+
+type relativeFormatOptionsRe = {
+  .
+  "style": option(relativeStyle),
+  "units": option(units),
+  "format": option(string),
+  "now": option(int),
+};
+
+type relativeFormatOptionsJs = {
+  .
+  "style": Js.nullable(string),
+  "units": Js.nullable(string),
+  "format": Js.nullable(string),
+  "now": Js.nullable(int),
+};
+
+let mapReasonRelativeFormatOptionsToJs =
+    (options: relativeFormatOptionsRe): relativeFormatOptionsJs => {
+  "style": options##style |> mapReasonRelativeStyleToJs,
+  "units": options##units |> mapReasonUnitsToJs,
+  "format": options##format |> Js.Nullable.fromOption,
+  "now": options##now |> Js.Nullable.fromOption,
+};
+
+type numberStyle =
+  | DecimalNumberStyle
+  | CurrencyNumberStyle
+  | PercentNumberStyle;
+
+let mapReasonNumberStyleToJs = numberStyle =>
+  Js.Option.map(
+    (. numberStyle) =>
+      switch (numberStyle) {
+      | DecimalNumberStyle => "decimal"
+      | CurrencyNumberStyle => "currency"
+      | PercentNumberStyle => "percent"
+      },
+    numberStyle,
+  )
+  |> Js.Nullable.fromOption;
+
+type currencyDisplay =
+  | SymbolCurrencyDisplay
+  | CodeCurrencyDisplay
+  | NameCurrencyDisplay;
+
+let mapReasonCurrencyDisplayToJs = currencyDisplay =>
+  Js.Option.map(
+    (. currencyDisplay) =>
+      switch (currencyDisplay) {
+      | SymbolCurrencyDisplay => "symbol"
+      | CodeCurrencyDisplay => "code"
+      | NameCurrencyDisplay => "name"
+      },
+    currencyDisplay,
+  )
+  |> Js.Nullable.fromOption;
+
+type numberFormatOptionsRe = {
+  .
+  "localeMatcher": option(localeMatcher),
+  "style": option(numberStyle),
+  "currency": option(string),
+  "currencyDisplay": option(currencyDisplay),
+  "useGrouping": option(bool),
+  "minimumIntegerDigits": option(int),
+  "minimumFractionDigits": option(int),
+  "maximumFractionDigits": option(int),
+  "minimumSignificantDigits": option(int),
+  "maximumSignificantDigits": option(int),
+};
+
+type numberFormatOptionsJs = {
+  .
+  "localeMatcher": Js.nullable(string),
+  "style": Js.nullable(string),
+  "currency": Js.nullable(string),
+  "currencyDisplay": Js.nullable(string),
+  "useGrouping": Js.nullable(bool),
+  "minimumIntegerDigits": Js.nullable(int),
+  "minimumFractionDigits": Js.nullable(int),
+  "maximumFractionDigits": Js.nullable(int),
+  "minimumSignificantDigits": Js.nullable(int),
+  "maximumSignificantDigits": Js.nullable(int),
+};
+
+let mapReasonNumberFormatOptionsToJs = options => {
+  "localeMatcher": options##localeMatcher |> mapReasonLocaleMatcherToJs,
+  "style": options##style |> mapReasonNumberStyleToJs,
+  "currency": options##currency |> Js.Nullable.fromOption,
+  "currencyDisplay": options##currencyDisplay |> mapReasonCurrencyDisplayToJs,
+  "useGrouping": options##useGrouping |> Js.Nullable.fromOption,
+  "minimumIntegerDigits":
+    options##minimumIntegerDigits |> Js.Nullable.fromOption,
+  "minimumFractionDigits":
+    options##minimumFractionDigits |> Js.Nullable.fromOption,
+  "maximumFractionDigits":
+    options##maximumFractionDigits |> Js.Nullable.fromOption,
+  "minimumSignificantDigits":
+    options##minimumSignificantDigits |> Js.Nullable.fromOption,
+  "maximumSignificantDigits":
+    options##maximumSignificantDigits |> Js.Nullable.fromOption,
+};
+
+type pluralStyle =
+  | CardinalPluralStyle
+  | OrdinalPluralStyle;
+
+let mapReasonPluralStyleToJs = pluralStyle =>
+  Js.Option.map(
+    (. pluralStyle) =>
+      switch (pluralStyle) {
+      | CardinalPluralStyle => "cardinal"
+      | OrdinalPluralStyle => "ordinal"
+      },
+    pluralStyle,
+  )
+  |> Js.Nullable.fromOption;
+
+type pluralFormatOptionsRe = {. "style": option(pluralStyle)};
+
+type pluralFormatOptionsJs = {. "style": Js.nullable(string)};
+
+let mapReasonPluralFormatOptionsToJs = options => {
+  "style": options##style |> mapReasonPluralStyleToJs,
+};
+
+/* Components */
+type domTag =
+  | Span
+  | Div
+  | H1
+  | H2
+  | H3
+  | H4
+  | H5
+  | H6
+  | P
+  | Strong
+  | B
+  | I
+  | Em
+  | Mark
+  | Small
+  | Del
+  | Ins
+  | Sub
+  | Sup;
+
+type textComponent =
+  | DomTag(domTag)
+  | ReactComponent(ReasonReact.reactClass);
+
+let mapDomTagToString = tag =>
+  switch (tag) {
+  | Span => "span"
+  | Div => "div"
+  | P => "p"
+  | H1 => "h1"
+  | H2 => "h2"
+  | H3 => "h3"
+  | H4 => "h4"
+  | H5 => "h5"
+  | H6 => "h6"
+  | Strong => "strong"
+  | B => "b"
+  | I => "i"
+  | Em => "em"
+  | Mark => "mark"
+  | Small => "small"
+  | Del => "del"
+  | Ins => "ins"
+  | Sub => "sub"
+  | Sup => "sup"
+  };
+
+let mapOptDomTagToString = tag =>
+  switch (tag) {
+  | Some(tag) => Some(tag |> mapDomTagToString)
+  | None => None
+  };
+
+let mapTextComponentToJs = textComponent =>
+  switch (textComponent) {
+  | DomTag(domTag) => mapDomTagToString(domTag)->Obj.magic
+  | ReactComponent(reactComponent) => reactComponent->Obj.magic
+  };
+
+let mapOptTextComponentToJs = textComponent =>
+  textComponent->Belt.Option.map(mapTextComponentToJs);
+
+type errorHandler = string => unit;
+
+module IntlProvider = {
+  [@bs.module "react-intl"]
+  external reactClass: ReasonReact.reactClass = "IntlProvider";
+  let make =
+      (
+        ~locale: option(string)=?,
+        ~formats: option(Js.t({..}))=?, /* TODO */
+        ~messages: option(Js.Dict.t(string))=?,
+        ~defaultLocale: option(string)=?,
+        ~defaultFormats: option(Js.t({..}))=?, /* TODO */
+        ~textComponent: option(textComponent)=?,
+        ~initialNow: option(int)=?,
+        ~onError: option(errorHandler)=?,
+        children,
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass,
+      ~props={
+        "locale": locale |> Js.Nullable.fromOption,
+        "formats": formats |> Js.Nullable.fromOption,
+        "messages": messages |> Js.Nullable.fromOption,
+        "defaultLocale": defaultLocale |> Js.Nullable.fromOption,
+        "defaultFormats": defaultFormats |> Js.Nullable.fromOption,
+        "textComponent":
+          textComponent |> mapOptTextComponentToJs |> Js.Nullable.fromOption,
+        "initialNow": initialNow |> Js.Nullable.fromOption,
+        "onError": onError |> Js.Nullable.fromOption,
+      },
+      children,
+    );
+};
+
+type intlJs('t) =
+  {
+    .
+    "locale": string,
+    "formats": Js.t({..}), /* TODO */
+    "messages": Js.Dict.t(string),
+    "defaultLocale": string,
+    "defaultFormats": Js.t({..}), /* TODO */
+    "formatDate":
+      [@bs.meth] (
+        (Js.Date.t, Js.nullable(dateTimeFormatOptionsJs)) => string
+      ),
+    "formatTime":
+      [@bs.meth] (
+        (Js.Date.t, Js.nullable(dateTimeFormatOptionsJs)) => string
+      ),
+    "formatRelative":
+      [@bs.meth] (
+        (Js.Date.t, Js.nullable(relativeFormatOptionsJs)) => string
+      ),
+    "formatNumber":
+      [@bs.meth] ((float, Js.nullable(numberFormatOptionsJs)) => string),
+    "formatPlural":
+      [@bs.meth] ((int, Js.nullable(pluralFormatOptionsJs)) => string),
+    "formatMessage":
+      [@bs.meth] ((message, Js.nullable(Js.t({..}))) => string),
+    "formatHTMLMessage":
+      [@bs.meth] ((message, Js.nullable(Js.t({..}))) => string),
+    "now": [@bs.meth] (unit => int),
+  } as 't;
+
+type intl('t) = {
+  locale: string,
+  formats: Js.t({..} as 't), /* TODO */
+  messages: Js.Dict.t(string),
+  defaultLocale: string,
+  defaultFormats: Js.t({..} as 't), /* TODO */
+  formatDate: Js.Date.t => string,
+  formatDateWithOptions: (dateTimeFormatOptionsRe, Js.Date.t) => string,
+  formatTime: Js.Date.t => string,
+  formatTimeWithOptions: (dateTimeFormatOptionsRe, Js.Date.t) => string,
+  formatRelative: Js.Date.t => string,
+  formatRelativeWithOptions: (relativeFormatOptionsRe, Js.Date.t) => string,
+  formatInt: int => string,
+  formatIntWithOptions: (numberFormatOptionsRe, int) => string,
+  formatFloat: float => string,
+  formatFloatWithOptions: (numberFormatOptionsRe, float) => string,
+  formatPlural: int => string,
+  formatPluralWithOptions: (pluralFormatOptionsRe, int) => string,
+  formatMessage: message => string,
+  formatMessageWithValues: (Js.t({..} as 't), message) => string,
+  formatHTMLMessage: message => string,
+  formatHTMLMessageWithValues: (Js.t({..} as 't), message) => string,
+  now: unit => int,
+};
+
+let mapIntlJsToReason = (intlJs: intlJs('t)): intl('a) => {
+  locale: intlJs##locale,
+  formats: intlJs##formats,
+  messages: intlJs##messages,
+  defaultLocale: intlJs##defaultLocale,
+  defaultFormats: intlJs##defaultFormats,
+  formatDate: value =>
+    intlJs##formatDate(value, None |> Js.Nullable.fromOption),
+  formatDateWithOptions: (options, value) =>
+    intlJs##formatDate(
+      value,
+      Some(options |> mapReasonDateTimeFormatOptionsToJs)
+      |> Js.Nullable.fromOption,
+    ),
+  formatTime: value =>
+    intlJs##formatTime(value, None |> Js.Nullable.fromOption),
+  formatTimeWithOptions: (options, value) =>
+    intlJs##formatTime(
+      value,
+      Some(options |> mapReasonDateTimeFormatOptionsToJs)
+      |> Js.Nullable.fromOption,
+    ),
+  formatRelative: value =>
+    intlJs##formatRelative(value, None |> Js.Nullable.fromOption),
+  formatRelativeWithOptions: (options, value) =>
+    intlJs##formatRelative(
+      value,
+      Some(options |> mapReasonRelativeFormatOptionsToJs)
+      |> Js.Nullable.fromOption,
+    ),
+  formatInt: value =>
+    intlJs##formatNumber(
+      value |> float_of_int,
+      None |> Js.Nullable.fromOption,
+    ),
+  formatIntWithOptions: (options, value) =>
+    intlJs##formatNumber(
+      value |> float_of_int,
+      Some(options |> mapReasonNumberFormatOptionsToJs)
+      |> Js.Nullable.fromOption,
+    ),
+  formatFloat: value =>
+    intlJs##formatNumber(value, None |> Js.Nullable.fromOption),
+  formatFloatWithOptions: (options, value) =>
+    intlJs##formatNumber(
+      value,
+      Some(options |> mapReasonNumberFormatOptionsToJs)
+      |> Js.Nullable.fromOption,
+    ),
+  formatPlural: value =>
+    intlJs##formatPlural(value, None |> Js.Nullable.fromOption),
+  formatPluralWithOptions: (options, value) =>
+    intlJs##formatPlural(
+      value,
+      Some(options |> mapReasonPluralFormatOptionsToJs)
+      |> Js.Nullable.fromOption,
+    ),
+  formatMessage: message =>
+    intlJs##formatMessage(message, None |> Js.Nullable.fromOption),
+  formatMessageWithValues: (values, message) =>
+    intlJs##formatMessage(message, Some(values) |> Js.Nullable.fromOption),
+  formatHTMLMessage: message =>
+    intlJs##formatHTMLMessage(message, None |> Js.Nullable.fromOption),
+  formatHTMLMessageWithValues: (values, message) =>
+    intlJs##formatHTMLMessage(
+      message,
+      Some(values) |> Js.Nullable.fromOption,
+    ),
+  now: () => intlJs##now(),
+};
+
+module IntlInjector = {
+  let reactClass: ReasonReact.reactClass = [%bs.raw
+    {|
+    require("react-intl").injectIntl(function(_ref) {
+      var intl = _ref.intl, children = _ref.children;
+      return children(intl);
+    })
+    |}
+  ];
+  let make = children =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass, ~props=Js.Obj.empty(), (intlJs: intlJs('t)) =>
+      children(mapIntlJsToReason(intlJs))
+    );
+};
+
+module FormattedMessage = {
+  [@bs.module "react-intl"]
+  external reactClass: ReasonReact.reactClass = "FormattedMessage";
+  let make =
+      (
+        ~id: string,
+        ~defaultMessage: string,
+        ~values: option(Js.t({..}))=?,
+        ~tagName: option(domTag)=?,
+        _,
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass,
+      ~props={
+        "id": id,
+        "defaultMessage": defaultMessage,
+        "values": values |> Js.Nullable.fromOption,
+        "tagName": tagName |> mapOptDomTagToString |> Js.Nullable.fromOption,
+      },
+      [||],
+    );
+};
+
+/* DefinedMessage is another wrapper for FormattedMessage.
+   It takes the id and defaultMessage props from a passed message object. */
+module DefinedMessage = {
+  [@bs.module "react-intl"]
+  external reactClass: ReasonReact.reactClass = "FormattedMessage";
+  let make =
+      (
+        ~message: message,
+        ~values: option(Js.t({..}))=?,
+        ~tagName: option(domTag)=?,
+        _,
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass,
+      ~props={
+        "id": message##id,
+        "defaultMessage": message##defaultMessage,
+        "values": values |> Js.Nullable.fromOption,
+        "tagName": tagName |> mapOptDomTagToString |> Js.Nullable.fromOption,
+      },
+      [||],
+    );
+};
+
+module FormattedDate = {
+  [@bs.module "react-intl"]
+  external reactClass: ReasonReact.reactClass = "FormattedDate";
+  let make =
+      (
+        ~value: Js.Date.t,
+        ~format: option(string)=?,
+        ~localeMatcher: option(localeMatcher)=?,
+        ~formatMatcher: option(formatMatcher)=?,
+        ~timeZone: option(string)=?,
+        ~hour12: option(bool)=?,
+        ~weekday: option(textualFormat)=?,
+        ~era: option(textualFormat)=?,
+        ~year: option(numeralFormat)=?,
+        ~month: option(mixedFormat)=?,
+        ~day: option(numeralFormat)=?,
+        ~hour: option(numeralFormat)=?,
+        ~minute: option(numeralFormat)=?,
+        ~second: option(numeralFormat)=?,
+        ~timeZoneName: option(timeZoneName)=?,
+        _,
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass,
+      ~props={
+        "value": value,
+        "format": format |> Js.Nullable.fromOption,
+        "localeMatcher": localeMatcher |> mapReasonLocaleMatcherToJs,
+        "formatMatcher": formatMatcher |> mapReasonFormatMatcherToJs,
+        "timeZone": timeZone |> Js.Nullable.fromOption,
+        "hour12": hour12 |> Js.Nullable.fromOption,
+        "weekday": weekday |> mapReasonTextualFormatToJs,
+        "era": era |> mapReasonTextualFormatToJs,
+        "year": year |> mapReasonNumeralFormatToJs,
+        "month": month |> mapReasonMixedFormatToJs,
+        "day": day |> mapReasonNumeralFormatToJs,
+        "hour": hour |> mapReasonNumeralFormatToJs,
+        "minute": minute |> mapReasonNumeralFormatToJs,
+        "second": second |> mapReasonNumeralFormatToJs,
+        "timeZoneName": timeZoneName |> mapReasonTimeZoneNameToJs,
+      },
+      [||],
+    );
+};
+
+module FormattedTime = {
+  [@bs.module "react-intl"]
+  external reactClass: ReasonReact.reactClass = "FormattedTime";
+  let make =
+      (
+        ~value: Js.Date.t,
+        ~format: option(string)=?,
+        ~localeMatcher: option(localeMatcher)=?,
+        ~formatMatcher: option(formatMatcher)=?,
+        ~timeZone: option(string)=?,
+        ~hour12: option(bool)=?,
+        ~weekday: option(textualFormat)=?,
+        ~era: option(textualFormat)=?,
+        ~year: option(numeralFormat)=?,
+        ~month: option(mixedFormat)=?,
+        ~day: option(numeralFormat)=?,
+        ~hour: option(numeralFormat)=?,
+        ~minute: option(numeralFormat)=?,
+        ~second: option(numeralFormat)=?,
+        ~timeZoneName: option(timeZoneName)=?,
+        _,
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass,
+      ~props={
+        "value": value,
+        "format": format |> Js.Nullable.fromOption,
+        "localeMatcher": localeMatcher |> mapReasonLocaleMatcherToJs,
+        "formatMatcher": formatMatcher |> mapReasonFormatMatcherToJs,
+        "timeZone": timeZone |> Js.Nullable.fromOption,
+        "hour12": hour12 |> Js.Nullable.fromOption,
+        "weekday": weekday |> mapReasonTextualFormatToJs,
+        "era": era |> mapReasonTextualFormatToJs,
+        "year": year |> mapReasonNumeralFormatToJs,
+        "month": month |> mapReasonMixedFormatToJs,
+        "day": day |> mapReasonNumeralFormatToJs,
+        "hour": hour |> mapReasonNumeralFormatToJs,
+        "minute": minute |> mapReasonNumeralFormatToJs,
+        "second": second |> mapReasonNumeralFormatToJs,
+        "timeZoneName": timeZoneName |> mapReasonTimeZoneNameToJs,
+      },
+      [||],
+    );
+};
+
+/* Utils */
+let wrapUnicodeString = (input: string) => {j|$input|j};
+
+let wrapOptUnicodeString = (input: Js.nullable(string)) =>
+  switch (input |> Js.Nullable.toOption) {
+  | Some(input) => input |> wrapUnicodeString
+  | None => ""
+  };
+
+let messagesArrayToDict = (translation: jsonMessages) =>
+  translation
+  |> Array.fold_left(
+       (dict, message) => {
+         let unicodeMessage = message##message |> wrapOptUnicodeString;
+         let unicodeDefaultMessage =
+           message##defaultMessage |> wrapUnicodeString;
+         Js.Dict.set(
+           dict,
+           message##id,
+           unicodeMessage !== "" ? unicodeMessage : unicodeDefaultMessage,
+         );
+         dict;
+       },
+       Js.Dict.empty(),
+     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,11 +902,6 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1.js@^4.0.0:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.9.2.tgz#8117ef4f7ed87cd8f89044b5bff97ac243a16c9a"
@@ -1167,10 +1162,10 @@ browserslist@^4.1.0, browserslist@^4.3.4:
     electron-to-chromium "^1.3.122"
     node-releases "^1.1.13"
 
-bs-platform@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.0.tgz#f9fded818bafc3891aeb85eb4e0d95b8d8f8b4d7"
-  integrity sha512-zxLobdIaf/r7go47hOgxcd6C0ANh7MYMEtZNb9Al7JdoekzFZI50F4GpZpP8kMh9Z+M5PoPE1WuryT4S8mT8Kg==
+bs-platform@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.3.tgz#2b167603ef52574cb9534fabab702f6013715e6c"
+  integrity sha512-GAeypBebeDGTay5kJ3v5Z3Whp1Q4zQ0hAttflVtPG3zps88xDZnVAlS3JGIIBDmJFEMyNtv5947a/IWKvWXcPw==
 
 bs-react-intl-extractor-bin@0.7.0:
   version "0.7.0"
@@ -1491,11 +1486,6 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^2.4.0:
   version "2.5.7"
@@ -2078,13 +2068,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
@@ -2299,19 +2282,6 @@ fastparse@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
-
-fbjs@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  integrity sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
 
 filesize@^3.6.0:
   version "3.6.1"
@@ -2679,11 +2649,6 @@ iconv-lite@0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@~0.4.13:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-  integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
-
 icss-replace-symbols@1.1.0, icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -2948,11 +2913,6 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-stream@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
-
 is-svg@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
@@ -3011,14 +2971,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -3458,14 +3410,6 @@ node-addon-api@^1.6.0:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.3.tgz#3998d4593e2dca2ea82114670a4eb003386a9fe1"
   integrity sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg==
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@^0.7.1:
   version "0.7.6"
@@ -4540,13 +4484,6 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 prop-types@15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -4555,15 +4492,6 @@ prop-types@15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
-
-prop-types@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
-  integrity sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
 
 prop-types@^15.6.2:
   version "15.6.2"
@@ -4673,7 +4601,7 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.8.6:
+react-dom@16.8.6, react-dom@>=16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
@@ -4682,16 +4610,6 @@ react-dom@16.8.6:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
-
-"react-dom@>=15.0.0 || >=16.0.0":
-  version "16.1.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.1.1.tgz#b2e331b6d752faf1a2d31399969399a41d8d45f8"
-  integrity sha512-q06jiwST8SEPAMIEkAsu7BgynEZtqF87VrTc70XsW7nxVhWEu2Y4MF5UfxxHQO/mNtQHQWP0YcFxmwm9oMrMaQ==
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
 
 react-intl@2.8.0:
   version "2.8.0"
@@ -4709,7 +4627,7 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react@16.8.6:
+react@16.8.6, react@>=16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
@@ -4718,16 +4636,6 @@ react@16.8.6:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
-
-"react@>=15.0.0 || >=16.0.0":
-  version "16.1.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.1.1.tgz#d5c4ef795507e3012282dd51261ff9c0e824fe1f"
-  integrity sha512-FQfiFfk2z2Fk87OngNJHT05KyC9DOVn8LPeB7ZX+9u5+yU1JK6o5ozRlU3PeOMr0IFkWNvgn9jU8/IhRxR1F0g==
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
 
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.6, readable-stream@^2.3.3:
   version "2.3.3"
@@ -4765,13 +4673,13 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-reason-react@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.6.0.tgz#e9a7d6a10958161c3a12ef7fec1b6662edaae94a"
-  integrity sha512-FKzBDXE96KPyUbeRo2ToqUe9rl4IKgwegtjCXvyx0bzJXCKLqwiiN3OiOTH/siJS+/IZRZhBAHnd/R3VkRMsMQ==
+reason-react@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.7.0.tgz#46a975c321e81cd51310d7b1a02418ca7667b0d6"
+  integrity sha512-czR/f0lY5iyLCki9gwftOFF5Zs40l7ZSFmpGK/Z6hx2jBVeFDmIiXB8bAQW/cO6IvtuEt97OmsYueiuOYG9XjQ==
   dependencies:
-    react ">=15.0.0 || >=16.0.0"
-    react-dom ">=15.0.0 || >=16.0.0"
+    react ">=16.8.1"
+    react-dom ">=16.8.1"
 
 reduce-css-calc@^2.0.0:
   version "2.1.4"
@@ -5108,7 +5016,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -5588,11 +5496,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
-  integrity sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==
-
 uncss@^0.16.2:
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/uncss/-/uncss-0.16.2.tgz#3b2269c59012da7c66cbe98fbedddeef94f0649c"
@@ -5783,11 +5686,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-  integrity sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,10 +2560,12 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 hsl-regex@^1.0.0:
   version "1.0.0"
@@ -2699,29 +2701,32 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-intl-format-cache@^2.0.5:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"
-  integrity sha1-BKNp/sv61tpgBbrh8UMzMy3PkxY=
+intl-format-cache@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-3.0.2.tgz#d83f5d659e2eb00d8d575fe104d30e5c2affad2d"
+  integrity sha512-/cRGShV1FaYpD4pO/mCf3r+00iasUbkV0qp5ai0TZ0FHpZxAigi3CCkLc9me4Smd8/XpjDT2pLY/5iRmnN7r0g==
 
-intl-messageformat-parser@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
-  integrity sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=
+intl-locales-supported@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/intl-locales-supported/-/intl-locales-supported-1.1.0.tgz#6f04e86464b527a84850b7f554ac2a0246d55ded"
+  integrity sha512-EDOpb+LUqTBdOsB24NtW/Tostabhh2JMHDcL4hClXHr4IPqGQL9oTYzmNQWOHwIa7ZjsZSYHSiHXS0iHUwfh2A==
 
-intl-messageformat@^2.0.0, intl-messageformat@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.2.0.tgz#345bcd46de630b7683330c2e52177ff5eab484fc"
-  integrity sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=
+intl-messageformat-parser@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.6.6.tgz#ac803a94f2b94ef575287038ee8ccc2fc876a255"
+  integrity sha512-MfBWPyCUIrRM1rB6rVdvkv8LxOxo17sLF/XVyOKV0MypU1WL3NuDVC5Ng27Q9zUsikU9vJCzqCEzI8ZEccUsmA==
+
+intl-messageformat@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-4.0.1.tgz#8641034548ed06716c0a0ee6183a426bd7d31992"
+  integrity sha512-xWPjRs3oyaSGp8dCzx1VAn/C4Fqy59eEvJq7m3RrEn6mzJ32/cR+jVLBlEWMNC31GSmkbtXfFMLYeMAXiV0oUg==
   dependencies:
-    intl-messageformat-parser "1.4.0"
+    intl-messageformat-parser "^1.6.6"
 
-intl-relativeformat@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz#010f1105802251f40ac47d0e3e1a201348a255df"
-  integrity sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=
-  dependencies:
-    intl-messageformat "^2.0.0"
+intl-relativeformat@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-6.1.1.tgz#ed60fcd7460469b45c4588ece7b61e1c697c401d"
+  integrity sha512-KkkuLnq+rJur77pTUuDNA8j2z3n7lj+R2IXLF0uArADngYPWByuY95pJ7DPxiTokXW49FadV887/I/W7arCWew==
 
 invariant@^2.1.1:
   version "2.2.2"
@@ -4601,11 +4606,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-display-name@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.4.tgz#e2a670b81d79a2204335510c01246f4c92ff12cf"
-  integrity sha512-zvU6iouW+SWwHTyThwxGICjJYCMZFk/6r/+jmOdC7ntQoPlS/Pqb81MkxaMf2bHTSq9TN3K3zX2/ayMW/jCtyA==
-
 react-dom@16.8.6, react-dom@>=16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -4616,19 +4616,21 @@ react-dom@16.8.6, react-dom@>=16.8.1:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-intl@3.0.0-beta-1:
-  version "3.0.0-beta-1"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.0.0-beta-1.tgz#de6f91fb7b3409b81fac90dc029d281b54b6bbd4"
-  integrity sha512-ZH9iKrod9ojg1AX7XnntBcD/t1C2+MNy6NZLoqiarUSsyaj/uOZUPQhIQM2MgCi3n2aOu1PjYxde8iMORYxfhQ==
+react-intl@3.0.0-beta-8:
+  version "3.0.0-beta-8"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.0.0-beta-8.tgz#6e638a494b02f5228c11737cf9c51f826d137738"
+  integrity sha512-706VWfLATgIUAGB6oLkWUIv3krsI8YmhC5wMrDzAScg/OSgn2lAmUviNheACb87BmJfSGb4LUaDWz0UN3qUYeg==
   dependencies:
-    hoist-non-react-statics "^2.5.5"
-    intl-format-cache "^2.0.5"
-    intl-messageformat "^2.1.0"
-    intl-relativeformat "^2.1.0"
+    hoist-non-react-statics "^3.3.0"
+    intl-format-cache "^3.0.0"
+    intl-locales-supported "^1.0.10"
+    intl-messageformat "^4.0.0"
+    intl-relativeformat "^6.1.0"
     invariant "^2.1.1"
-    react-display-name "^0.2.4"
+    react-is "^16.3.1"
+    shallow-equal "^1.1.0"
 
-react-is@^16.8.1:
+react-is@^16.3.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
@@ -5044,6 +5046,11 @@ shallow-copy@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
   integrity sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=
+
+shallow-equal@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.0.tgz#fd828d2029ff4e19569db7e19e535e94e2d1f5cc"
+  integrity sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==
 
 shebang-command@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4601,6 +4601,11 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-display-name@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.4.tgz#e2a670b81d79a2204335510c01246f4c92ff12cf"
+  integrity sha512-zvU6iouW+SWwHTyThwxGICjJYCMZFk/6r/+jmOdC7ntQoPlS/Pqb81MkxaMf2bHTSq9TN3K3zX2/ayMW/jCtyA==
+
 react-dom@16.8.6, react-dom@>=16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -4611,16 +4616,17 @@ react-dom@16.8.6, react-dom@>=16.8.1:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-intl@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.8.0.tgz#20b0c1f01d1292427768aa8ec9e51ab7e36503ba"
-  integrity sha512-1cSasNkHxZOXYYhms9Q1tSEWF8AWZQNq3nPLB/j8mYV0ZTSt2DhGQXHfKrKQMu4cgj9J1Crqg7xFPICTBgzqtQ==
+react-intl@3.0.0-beta-1:
+  version "3.0.0-beta-1"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.0.0-beta-1.tgz#de6f91fb7b3409b81fac90dc029d281b54b6bbd4"
+  integrity sha512-ZH9iKrod9ojg1AX7XnntBcD/t1C2+MNy6NZLoqiarUSsyaj/uOZUPQhIQM2MgCi3n2aOu1PjYxde8iMORYxfhQ==
   dependencies:
     hoist-non-react-statics "^2.5.5"
     intl-format-cache "^2.0.5"
     intl-messageformat "^2.1.0"
     intl-relativeformat "^2.1.0"
     invariant "^2.1.1"
+    react-display-name "^0.2.4"
 
 react-is@^16.8.1:
   version "16.8.6"


### PR DESCRIPTION
Published `bs-react-intl@0.9.0-beta.1` (or `bs-react-intl@next`) with hooks api support.

~But it won't work as is due to `react-intl` itself doesn't support new context api yet.~

~To make it consumable, `react-intl` must be resolved to the [fork](https://github.com/yahoo/react-intl/pull/1186#issuecomment-483271274).~

~You can do this via webpack config:~

**UPDATE:** Latest `bs-react-intl` beta works with the latest `react-intl` beta and supports hooks out of the box.

P.S. Old api is still available via `ReactIntlCompat`.