### PR TITLE
Adaptations for react-intl 3.0.0b8

### DIFF
--- a/examples/index.re
+++ b/examples/index.re
@@ -1,9 +1,1 @@
-[@bs.module "react-intl/locale-data/en"]
-external en: ReactIntl.localeData('t) = "default";
-[@bs.module "react-intl/locale-data/ru"]
-external ru: ReactIntl.localeData('t) = "default";
-
-ReactIntl.addLocaleData(en);
-ReactIntl.addLocaleData(ru);
-
 ReactDOMRe.renderToElementWithId(<App />, "app");

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "bs-platform": "^5.0.3",
-    "react-intl": "^2.7.1",
+    "react-intl": "3.0.0-beta-8",
     "reason-react": "^0.7.0"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-intl": "3.0.0-beta-1",
+    "react-intl": "3.0.0-beta-8",
     "reason-react": "0.7.0"
   },
   "repository": {

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -1,7 +1,3 @@
-type localeData('t) = {.. "locale": string} as 't;
-
-[@bs.module "react-intl"] external addLocaleData: localeData('t) => unit = "";
-
 type dateTimeFormatOptions;
 
 [@bs.obj]
@@ -134,10 +130,7 @@ module Intl = {
 [@bs.val] [@bs.module "react-intl"]
 external context: React.Context.t(Intl.t) = "IntlContext";
 
-// Not in react-intl yet
-// [@bs.module "react-intl"] external useIntl: unit => intl = "";
-
-let useIntl = () => context->React.useContext; // not zero-cost but will be when react-intl will add it
+[@bs.module "react-intl"] external useIntl: unit => Intl.t = "";
 
 type textComponent;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,10 +2560,12 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 hsl-regex@^1.0.0:
   version "1.0.0"
@@ -2699,29 +2701,32 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-intl-format-cache@^2.0.5:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"
-  integrity sha1-BKNp/sv61tpgBbrh8UMzMy3PkxY=
+intl-format-cache@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-3.0.2.tgz#d83f5d659e2eb00d8d575fe104d30e5c2affad2d"
+  integrity sha512-/cRGShV1FaYpD4pO/mCf3r+00iasUbkV0qp5ai0TZ0FHpZxAigi3CCkLc9me4Smd8/XpjDT2pLY/5iRmnN7r0g==
 
-intl-messageformat-parser@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
-  integrity sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=
+intl-locales-supported@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/intl-locales-supported/-/intl-locales-supported-1.1.0.tgz#6f04e86464b527a84850b7f554ac2a0246d55ded"
+  integrity sha512-EDOpb+LUqTBdOsB24NtW/Tostabhh2JMHDcL4hClXHr4IPqGQL9oTYzmNQWOHwIa7ZjsZSYHSiHXS0iHUwfh2A==
 
-intl-messageformat@^2.0.0, intl-messageformat@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.2.0.tgz#345bcd46de630b7683330c2e52177ff5eab484fc"
-  integrity sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=
+intl-messageformat-parser@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.6.6.tgz#ac803a94f2b94ef575287038ee8ccc2fc876a255"
+  integrity sha512-MfBWPyCUIrRM1rB6rVdvkv8LxOxo17sLF/XVyOKV0MypU1WL3NuDVC5Ng27Q9zUsikU9vJCzqCEzI8ZEccUsmA==
+
+intl-messageformat@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-4.0.1.tgz#8641034548ed06716c0a0ee6183a426bd7d31992"
+  integrity sha512-xWPjRs3oyaSGp8dCzx1VAn/C4Fqy59eEvJq7m3RrEn6mzJ32/cR+jVLBlEWMNC31GSmkbtXfFMLYeMAXiV0oUg==
   dependencies:
-    intl-messageformat-parser "1.4.0"
+    intl-messageformat-parser "^1.6.6"
 
-intl-relativeformat@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz#010f1105802251f40ac47d0e3e1a201348a255df"
-  integrity sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=
-  dependencies:
-    intl-messageformat "^2.0.0"
+intl-relativeformat@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-6.1.1.tgz#ed60fcd7460469b45c4588ece7b61e1c697c401d"
+  integrity sha512-KkkuLnq+rJur77pTUuDNA8j2z3n7lj+R2IXLF0uArADngYPWByuY95pJ7DPxiTokXW49FadV887/I/W7arCWew==
 
 invariant@^2.1.1:
   version "2.2.2"
@@ -4601,11 +4606,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-display-name@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.4.tgz#e2a670b81d79a2204335510c01246f4c92ff12cf"
-  integrity sha512-zvU6iouW+SWwHTyThwxGICjJYCMZFk/6r/+jmOdC7ntQoPlS/Pqb81MkxaMf2bHTSq9TN3K3zX2/ayMW/jCtyA==
-
 react-dom@16.8.6, react-dom@>=16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -4616,19 +4616,21 @@ react-dom@16.8.6, react-dom@>=16.8.1:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-intl@3.0.0-beta-1:
-  version "3.0.0-beta-1"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.0.0-beta-1.tgz#de6f91fb7b3409b81fac90dc029d281b54b6bbd4"
-  integrity sha512-ZH9iKrod9ojg1AX7XnntBcD/t1C2+MNy6NZLoqiarUSsyaj/uOZUPQhIQM2MgCi3n2aOu1PjYxde8iMORYxfhQ==
+react-intl@3.0.0-beta-8:
+  version "3.0.0-beta-8"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.0.0-beta-8.tgz#6e638a494b02f5228c11737cf9c51f826d137738"
+  integrity sha512-706VWfLATgIUAGB6oLkWUIv3krsI8YmhC5wMrDzAScg/OSgn2lAmUviNheACb87BmJfSGb4LUaDWz0UN3qUYeg==
   dependencies:
-    hoist-non-react-statics "^2.5.5"
-    intl-format-cache "^2.0.5"
-    intl-messageformat "^2.1.0"
-    intl-relativeformat "^2.1.0"
+    hoist-non-react-statics "^3.3.0"
+    intl-format-cache "^3.0.0"
+    intl-locales-supported "^1.0.10"
+    intl-messageformat "^4.0.0"
+    intl-relativeformat "^6.1.0"
     invariant "^2.1.1"
-    react-display-name "^0.2.4"
+    react-is "^16.3.1"
+    shallow-equal "^1.1.0"
 
-react-is@^16.8.1:
+react-is@^16.3.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
@@ -5044,6 +5046,11 @@ shallow-copy@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
   integrity sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=
+
+shallow-equal@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.0.tgz#fd828d2029ff4e19569db7e19e535e94e2d1f5cc"
+  integrity sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
* `useIntl` is now available in react-intl
* `addLocaleData was removed from react-intl, see https://github.com/formatjs/react-intl/blob/master/docs/Upgrade-Guide.md#migrate-to-using-native-intl-apis