### PR TITLE
Change message and translation to record types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - Removed `Intl.now`
   - `FormattedRelative` has been renamed to `FormattedRelativeTime` and its API has been changed as well
   - `Intl.formatRelative` has been renamed to `Intl.formatRelativeTime` and its API has been changed as well
+* **[ BREAKING ]** Changed `ReactIntl.message` to record type.
+* **[ BREAKING ]** Removed `ReactIntl.translation`.
 * **[ BREAKING ]** Removed `ReactIntlCompat`.
 
 # 1.1.0

--- a/examples/App.re
+++ b/examples/App.re
@@ -17,7 +17,7 @@ module WithRawIntlProvider = {
     let intlConfig =
       ReactIntl.intlConfig(
         ~locale=locale->Locale.toString,
-        ~messages=locale->Locale.translations->Util.translationsToDict,
+        ~messages=locale->Locale.translations->Translation.toDict,
         (),
       );
     let intlCache = ReactIntl.createIntlCache();
@@ -44,7 +44,7 @@ let make = () => {
 
   <ReactIntl.IntlProvider
     locale={locale->Locale.toString}
-    messages={locale->Locale.translations->Util.translationsToDict}>
+    messages={locale->Locale.translations->Translation.toDict}>
     <Page locale setLocale={locale => locale->SetLocale->dispatch} />
   </ReactIntl.IntlProvider>;
 };

--- a/examples/Locale.re
+++ b/examples/Locale.re
@@ -1,7 +1,7 @@
 [@bs.module "./translations/en.json"]
-external en: array(Util.translation) = "default";
+external en: array(Translation.t) = "default";
 [@bs.module "./translations/ru.json"]
-external ru: array(Util.translation) = "default";
+external ru: array(Translation.t) = "default";
 
 type locale =
   | En

--- a/examples/Locale.re
+++ b/examples/Locale.re
@@ -1,7 +1,7 @@
 [@bs.module "./translations/en.json"]
-external en: array(ReactIntl.translation) = "default";
+external en: array(Util.translation) = "default";
 [@bs.module "./translations/ru.json"]
-external ru: array(ReactIntl.translation) = "default";
+external ru: array(Util.translation) = "default";
 
 type locale =
   | En

--- a/examples/Page.re
+++ b/examples/Page.re
@@ -1,5 +1,4 @@
 open ReactIntl;
-open PageLocale;
 
 [@react.component]
 let make = (~locale, ~setLocale) => {
@@ -23,12 +22,12 @@ let make = (~locale, ~setLocale) => {
       <FormattedMessage id="page.world" defaultMessage="World" />
     </div>
     <div>
-      {intl->Intl.formatMessage(pageLocale##today)->React.string}
+      {intl->Intl.formatMessage(PageLocale.today)->React.string}
       " "->React.string
       {intl->Intl.formatDate(Js.Date.make())->React.string}
       " (intl.formatDate)"->React.string
       <br />
-      {intl->Intl.formatMessage(pageLocale##today)->React.string}
+      {intl->Intl.formatMessage(PageLocale.today)->React.string}
       " "->React.string
       <FormattedDate value={Js.Date.make()} />
       " (FormattedDate)"->React.string

--- a/examples/PageLocale.re
+++ b/examples/PageLocale.re
@@ -1,16 +1,6 @@
-let pageLocale =
-  [@intl.messages]
-  {
-    "hello": {
-      "id": "page.hello",
-      "defaultMessage": "Hello",
-    },
-    "world": {
-      "id": "page.world",
-      "defaultMessage": "World",
-    },
-    "today": {
-      "id": "page.today",
-      "defaultMessage": "Today is",
-    },
-  };
+open ReactIntl;
+[@intl.messages];
+
+let hello = {id: "page.hello", defaultMessage: "Hello"};
+let world = {id: "page.world", defaultMessage: "World"};
+let today = {id: "page.today", defaultMessage: "Today is"};

--- a/examples/Translation.re
+++ b/examples/Translation.re
@@ -1,10 +1,10 @@
-type translation = {
+type t = {
   id: string,
   defaultMessage: string,
   message: Js.nullable(string),
 };
 
-let translationsToDict = (translations: array(translation)) => {
+let toDict = (translations: array(t)) => {
   translations->Belt.Array.reduce(
     Js.Dict.empty(),
     (dict, entry) => {

--- a/examples/Util.re
+++ b/examples/Util.re
@@ -1,12 +1,18 @@
-let translationsToDict = (translations: array(ReactIntl.translation)) => {
+type translation = {
+  id: string,
+  defaultMessage: string,
+  message: Js.nullable(string),
+};
+
+let translationsToDict = (translations: array(translation)) => {
   translations->Belt.Array.reduce(
     Js.Dict.empty(),
     (dict, entry) => {
       dict->Js.Dict.set(
-        entry##id,
-        switch (entry##message->Js.Nullable.toOption) {
+        entry.id,
+        switch (entry.message->Js.Nullable.toOption) {
         | None
-        | Some("") => entry##defaultMessage
+        | Some("") => entry.defaultMessage
         | Some(message) => message
         },
       );

--- a/src/ReactIntl.re
+++ b/src/ReactIntl.re
@@ -90,16 +90,8 @@ external displayNameFormatOptions:
   displayNameFormatOptions;
 
 type message = {
-  .
-  "id": string,
-  "defaultMessage": string,
-};
-
-type translation = {
-  .
-  "id": string,
-  "defaultMessage": string,
-  "message": Js.nullable(string),
+  id: string,
+  defaultMessage: string,
 };
 
 type part = {


### PR DESCRIPTION
@alexfedoseev Also, I moved the `translation` type from the `ReactIntl` module to the `Util` module, as it is actually not used anywhere but in `Util`.

Note that I still need to release a new version of the extractor to make message extraction from PageLocale.re work again. I will do that once we have this PR merged.